### PR TITLE
Add orchestrators for new Discord events

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # Documentación
 
 Este directorio albergará la documentación técnica del bot (arquitectura, base de datos, despliegue y catálogo de comandos). Se irá llenando en las siguientes fases.
+
+- [Guía de intents](./intents.md): pasos para adaptar la matriz de intents según el entorno de despliegue.

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -1,0 +1,30 @@
+# Guía de intents
+
+El bot solicita por defecto los intents necesarios para trabajar con comandos de
+prefijo, automatizar onboarding y responder a eventos de reacción. La matriz
+por defecto incluye:
+
+- `Guilds`
+- `GuildMembers`
+- `GuildMessages`
+- `MessageContent`
+- `GuildMessageReactions`
+- `DirectMessages`
+
+## Ajustar intents por despliegue
+
+1. Edita `src/index.ts` para añadir o remover valores dentro de la propiedad
+   `intents` del `Client`.
+2. Documenta siempre en el comentario de arranque por qué el despliegue requiere
+   la configuración elegida. Esto facilita auditorías y revisiones de seguridad.
+3. Si el bot se ejecuta en modo *privileged* (por ejemplo, leyendo contenido de
+   mensajes), valida que la organización tenga habilitados los permisos en el
+   [Portal de Desarrolladores de Discord](https://discord.com/developers/applications).
+4. Los despliegues con requisitos regionales o legales distintos pueden dividir
+   la matriz de intents en entornos separados (`production`, `staging`, etc.)
+   creando variantes del archivo de configuración y seleccionándolas mediante
+   variables de entorno o *feature flags*.
+
+> ℹ️ **Recomendación**: mantén las pruebas unitarias actualizadas cuando ajustes
+> la matriz de intents. Esto permite detectar rápidamente si un evento deja de
+> recibir datos tras modificar los permisos del `Client`.

--- a/src/application/orchestrators/guildMemberAddOrchestrator.ts
+++ b/src/application/orchestrators/guildMemberAddOrchestrator.ts
@@ -1,0 +1,18 @@
+// ============================================================================
+// RUTA: src/application/orchestrators/guildMemberAddOrchestrator.ts
+// ============================================================================
+
+import type { GuildMember } from 'discord.js';
+
+import { logger } from '@/shared/logger/pino';
+
+export const handleGuildMemberAdd = async (member: GuildMember): Promise<void> => {
+  logger.info(
+    {
+      userId: member.id,
+      guildId: member.guild.id,
+      joinedAt: member.joinedTimestamp,
+    },
+    'Nuevo miembro detectado en el servidor.',
+  );
+};

--- a/src/application/orchestrators/messageCreateOrchestrator.ts
+++ b/src/application/orchestrators/messageCreateOrchestrator.ts
@@ -1,0 +1,68 @@
+// ============================================================================
+// RUTA: src/application/orchestrators/messageCreateOrchestrator.ts
+// ============================================================================
+
+import type { Message } from 'discord.js';
+
+import { MESSAGE_PREFIXES } from '@/shared/config/constants';
+import { messageGuards } from '@/shared/guards/message-guards';
+import { logger } from '@/shared/logger/pino';
+
+const PREFIX_COOLDOWN_BUCKET = 'legacy-prefix';
+const PREFIX_COOLDOWN_MS = 3_000;
+
+export const handleMessageCreate = async (message: Message): Promise<void> => {
+  if (message.author.bot) {
+    return;
+  }
+
+  const content = message.content ?? '';
+
+  if (!messageGuards.hasValidPrefix({ prefixes: MESSAGE_PREFIXES, content })) {
+    return;
+  }
+
+  const cooldownResult = messageGuards.registerCooldown({
+    bucket: PREFIX_COOLDOWN_BUCKET,
+    userId: message.author.id,
+    durationMs: PREFIX_COOLDOWN_MS,
+  });
+
+  if (!cooldownResult.allowed) {
+    const remainingSeconds = Math.max(1, Math.ceil((cooldownResult.remainingMs ?? 0) / 1_000));
+    await message.reply(
+      `Debes esperar ${remainingSeconds} segundo${remainingSeconds === 1 ? '' : 's'} antes de reutilizar comandos de prefijo.`,
+    );
+    return;
+  }
+
+  const spamResult = messageGuards.detectSpam({
+    userId: message.author.id,
+    content,
+  });
+
+  if (spamResult.isSpam) {
+    logger.warn(
+      {
+        userId: message.author.id,
+        channelId: message.channelId,
+        reason: spamResult.reason,
+        occurrences: spamResult.occurrences,
+      },
+      'Mensaje bloqueado por protección anti-spam.',
+    );
+
+    await message.reply('Tu mensaje fue bloqueado por el sistema anti-spam. Intenta nuevamente en unos segundos.');
+    return;
+  }
+
+  logger.info(
+    {
+      userId: message.author.id,
+      channelId: message.channelId,
+      guildId: message.guildId,
+      content,
+    },
+    'Comando de prefijo recibido y validado.',
+  );
+};

--- a/src/application/orchestrators/messageDeleteOrchestrator.ts
+++ b/src/application/orchestrators/messageDeleteOrchestrator.ts
@@ -1,0 +1,29 @@
+// ============================================================================
+// RUTA: src/application/orchestrators/messageDeleteOrchestrator.ts
+// ============================================================================
+
+import type { Message, PartialMessage } from 'discord.js';
+
+import { logger } from '@/shared/logger/pino';
+
+export const handleMessageDelete = async (message: Message | PartialMessage): Promise<void> => {
+  const baseLog = {
+    messageId: message.id,
+    channelId: message.channelId,
+    guildId: message.guildId,
+  } as const;
+
+  if (message.partial) {
+    logger.warn(baseLog, 'Se eliminó un mensaje parcial (sin contenido en caché).');
+    return;
+  }
+
+  logger.info(
+    {
+      ...baseLog,
+      authorId: message.author?.id,
+      hadAttachments: message.attachments.size > 0,
+    },
+    'Mensaje eliminado registrado.',
+  );
+};

--- a/src/application/orchestrators/messageReactionAddOrchestrator.ts
+++ b/src/application/orchestrators/messageReactionAddOrchestrator.ts
@@ -1,0 +1,28 @@
+// ============================================================================
+// RUTA: src/application/orchestrators/messageReactionAddOrchestrator.ts
+// ============================================================================
+
+import type { MessageReaction, PartialMessageReaction, PartialUser, User } from 'discord.js';
+
+import { logger } from '@/shared/logger/pino';
+
+export const handleMessageReactionAdd = async (
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser,
+): Promise<void> => {
+  if (user.bot) {
+    return;
+  }
+
+  const emojiIdentifier = reaction.emoji.id ?? reaction.emoji.name;
+
+  logger.debug(
+    {
+      emoji: emojiIdentifier,
+      messageId: reaction.message?.id,
+      channelId: reaction.message?.channelId,
+      userId: user.id,
+    },
+    'Reacción registrada correctamente.',
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,14 @@ import { env } from '@/shared/config/env';
 import { logger } from '@/shared/logger/pino';
 
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds],
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.DirectMessages,
+  ],
 });
 
 const registerEvent = (descriptor: AnyEventDescriptor): void => {
@@ -36,6 +43,12 @@ const registerEvent = (descriptor: AnyEventDescriptor): void => {
   client.on(descriptor.name, handler as (...listenerArgs: unknown[]) => void);
 };
 
+/**
+ * Arrancamos solicitando intents de miembros, mensajes, contenido y reacciones
+ * porque el bot combina comandos con prefijo en texto, automatiza bienvenidas y
+ * observa reacciones para flujos de tickets. `DirectMessages` permite asistir a
+ * usuarios que abren conversaciones privadas durante esos procesos.
+ */
 const bootstrap = async (): Promise<void> => {
   logger.info({ env: env.NODE_ENV }, 'Iniciando Dedos Bot...');
 

--- a/src/presentation/events/guildMemberAdd.ts
+++ b/src/presentation/events/guildMemberAdd.ts
@@ -1,0 +1,17 @@
+// ============================================================================
+// RUTA: src/presentation/events/guildMemberAdd.ts
+// ============================================================================
+
+import type { GuildMember } from 'discord.js';
+import { Events } from 'discord.js';
+
+import { handleGuildMemberAdd } from '@/application/orchestrators/guildMemberAddOrchestrator';
+import type { EventDescriptor } from '@/presentation/events/types';
+
+export const guildMemberAddEvent: EventDescriptor<typeof Events.GuildMemberAdd> = {
+  name: Events.GuildMemberAdd,
+  once: false,
+  async execute(member: GuildMember): Promise<void> {
+    await handleGuildMemberAdd(member);
+  },
+};

--- a/src/presentation/events/index.ts
+++ b/src/presentation/events/index.ts
@@ -2,9 +2,20 @@
 // RUTA: src/presentation/events/index.ts
 // ============================================================================
 
+import { guildMemberAddEvent } from '@/presentation/events/guildMemberAdd';
 import { interactionCreateEvent } from '@/presentation/events/interactionCreate';
+import { messageCreateEvent } from '@/presentation/events/messageCreate';
+import { messageDeleteEvent } from '@/presentation/events/messageDelete';
+import { messageReactionAddEvent } from '@/presentation/events/messageReactionAdd';
 import { readyEvent } from '@/presentation/events/ready';
 
-export const events = [readyEvent, interactionCreateEvent] as const;
+export const events = [
+  readyEvent,
+  interactionCreateEvent,
+  messageCreateEvent,
+  guildMemberAddEvent,
+  messageReactionAddEvent,
+  messageDeleteEvent,
+] as const;
 
 export type AnyEventDescriptor = (typeof events)[number];

--- a/src/presentation/events/messageCreate.ts
+++ b/src/presentation/events/messageCreate.ts
@@ -1,0 +1,17 @@
+// ============================================================================
+// RUTA: src/presentation/events/messageCreate.ts
+// ============================================================================
+
+import type { Message } from 'discord.js';
+import { Events } from 'discord.js';
+
+import { handleMessageCreate } from '@/application/orchestrators/messageCreateOrchestrator';
+import type { EventDescriptor } from '@/presentation/events/types';
+
+export const messageCreateEvent: EventDescriptor<typeof Events.MessageCreate> = {
+  name: Events.MessageCreate,
+  once: false,
+  async execute(message: Message): Promise<void> {
+    await handleMessageCreate(message);
+  },
+};

--- a/src/presentation/events/messageDelete.ts
+++ b/src/presentation/events/messageDelete.ts
@@ -1,0 +1,17 @@
+// ============================================================================
+// RUTA: src/presentation/events/messageDelete.ts
+// ============================================================================
+
+import type { Message, PartialMessage } from 'discord.js';
+import { Events } from 'discord.js';
+
+import { handleMessageDelete } from '@/application/orchestrators/messageDeleteOrchestrator';
+import type { EventDescriptor } from '@/presentation/events/types';
+
+export const messageDeleteEvent: EventDescriptor<typeof Events.MessageDelete> = {
+  name: Events.MessageDelete,
+  once: false,
+  async execute(message: Message | PartialMessage): Promise<void> {
+    await handleMessageDelete(message);
+  },
+};

--- a/src/presentation/events/messageReactionAdd.ts
+++ b/src/presentation/events/messageReactionAdd.ts
@@ -1,0 +1,20 @@
+// ============================================================================
+// RUTA: src/presentation/events/messageReactionAdd.ts
+// ============================================================================
+
+import type { MessageReaction, PartialMessageReaction, PartialUser, User } from 'discord.js';
+import { Events } from 'discord.js';
+
+import { handleMessageReactionAdd } from '@/application/orchestrators/messageReactionAddOrchestrator';
+import type { EventDescriptor } from '@/presentation/events/types';
+
+export const messageReactionAddEvent: EventDescriptor<typeof Events.MessageReactionAdd> = {
+  name: Events.MessageReactionAdd,
+  once: false,
+  async execute(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): Promise<void> {
+    await handleMessageReactionAdd(reaction, user);
+  },
+};

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -34,6 +34,8 @@ export const COOLDOWNS = Object.freeze({
   middlemanRequest: 60_000,
 });
 
+export const MESSAGE_PREFIXES = Object.freeze(['!', '?'] as const);
+
 export const PERMISSIONS = Object.freeze({
   staff: [PermissionFlagsBits.ManageGuild, PermissionFlagsBits.ModerateMembers] as const,
   admin: [PermissionFlagsBits.Administrator] as const,

--- a/src/shared/guards/message-guards.ts
+++ b/src/shared/guards/message-guards.ts
@@ -1,0 +1,122 @@
+// ============================================================================
+// RUTA: src/shared/guards/message-guards.ts
+// ============================================================================
+
+export interface PrefixCheckOptions {
+  readonly prefixes: readonly string[];
+  readonly content: string;
+}
+
+export interface CooldownOptions {
+  readonly bucket: string;
+  readonly userId: string;
+  readonly durationMs: number;
+  readonly now?: number;
+}
+
+export interface CooldownResult {
+  readonly allowed: boolean;
+  readonly remainingMs?: number;
+}
+
+export interface SpamOptions {
+  readonly userId: string;
+  readonly content: string;
+  readonly now?: number;
+  readonly windowMs?: number;
+  readonly maxDuplicates?: number;
+  readonly maxMentions?: number;
+}
+
+export interface SpamResult {
+  readonly isSpam: boolean;
+  readonly reason?: 'duplicates' | 'mentions';
+  readonly occurrences?: number;
+}
+
+const DEFAULT_SPAM_WINDOW = 10_000;
+const DEFAULT_SPAM_DUPLICATES = 3;
+const DEFAULT_SPAM_MENTIONS = 5;
+
+const cooldownRegistry = new Map<string, number>();
+const spamRegistry = new Map<string, { occurrences: number; content: string; expiresAt: number }>();
+
+const prefixCheck = ({ prefixes, content }: PrefixCheckOptions): boolean => {
+  const normalizedContent = content.trim();
+  if (normalizedContent.length === 0) {
+    return false;
+  }
+
+  return prefixes.some((prefix) => normalizedContent.startsWith(prefix));
+};
+
+const registerCooldown = ({ bucket, userId, durationMs, now = Date.now() }: CooldownOptions): CooldownResult => {
+  const key = `${bucket}:${userId}`;
+  const expiresAt = cooldownRegistry.get(key);
+
+  if (typeof expiresAt === 'number' && expiresAt > now) {
+    return {
+      allowed: false,
+      remainingMs: expiresAt - now,
+    };
+  }
+
+  cooldownRegistry.set(key, now + durationMs);
+
+  return { allowed: true };
+};
+
+const detectSpam = ({
+  userId,
+  content,
+  now = Date.now(),
+  windowMs = DEFAULT_SPAM_WINDOW,
+  maxDuplicates = DEFAULT_SPAM_DUPLICATES,
+  maxMentions = DEFAULT_SPAM_MENTIONS,
+}: SpamOptions): SpamResult => {
+  const mentionMatches = content.match(/<@!?\d{17,20}>/gu);
+  const mentionCount = mentionMatches?.length ?? 0;
+
+  if (mentionCount > maxMentions) {
+    return { isSpam: true, reason: 'mentions', occurrences: mentionCount };
+  }
+
+  const existing = spamRegistry.get(userId);
+
+  if (!existing || existing.expiresAt <= now || existing.content !== content) {
+    spamRegistry.set(userId, {
+      content,
+      occurrences: 1,
+      expiresAt: now + windowMs,
+    });
+
+    return { isSpam: false, occurrences: 1 };
+  }
+
+  const updatedOccurrences = existing.occurrences + 1;
+  spamRegistry.set(userId, {
+    ...existing,
+    occurrences: updatedOccurrences,
+    expiresAt: now + windowMs,
+  });
+
+  if (updatedOccurrences > maxDuplicates) {
+    return { isSpam: true, reason: 'duplicates', occurrences: updatedOccurrences };
+  }
+
+  return { isSpam: false, occurrences: updatedOccurrences };
+};
+
+const resetGuards = (): void => {
+  cooldownRegistry.clear();
+  spamRegistry.clear();
+};
+
+export const messageGuards = {
+  hasValidPrefix: prefixCheck,
+  registerCooldown,
+  detectSpam,
+  reset: resetGuards,
+};
+
+export type MessageGuards = typeof messageGuards;

--- a/tests/unit/application/orchestrators/guildMemberAddOrchestrator.test.ts
+++ b/tests/unit/application/orchestrators/guildMemberAddOrchestrator.test.ts
@@ -1,0 +1,39 @@
+import type { GuildMember } from 'discord.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { handleGuildMemberAdd } from '@/application/orchestrators/guildMemberAddOrchestrator';
+
+vi.mock('@/shared/logger/pino', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const createMember = (overrides: Partial<GuildMember> = {}): GuildMember =>
+  ({
+    id: 'user-1',
+    guild: { id: 'guild-1' },
+    joinedTimestamp: 1_700_000_000_000,
+    ...overrides,
+  } as unknown as GuildMember);
+
+describe('handleGuildMemberAdd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registra la llegada de un nuevo miembro', async () => {
+    const member = createMember();
+
+    await handleGuildMemberAdd(member);
+
+    const { logger } = await import('@/shared/logger/pino');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', guildId: 'guild-1' }),
+      'Nuevo miembro detectado en el servidor.',
+    );
+  });
+});

--- a/tests/unit/application/orchestrators/messageCreateOrchestrator.test.ts
+++ b/tests/unit/application/orchestrators/messageCreateOrchestrator.test.ts
@@ -1,0 +1,81 @@
+import type { Message } from 'discord.js';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleMessageCreate } from '@/application/orchestrators/messageCreateOrchestrator';
+import { messageGuards } from '@/shared/guards/message-guards';
+
+vi.mock('@/shared/logger/pino', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('handleMessageCreate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+    messageGuards.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const createMessage = (overrides: Partial<Message> = {}): Message => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    return {
+      author: { id: 'user-1', bot: false },
+      content: '!ping',
+      channelId: 'channel-1',
+      guildId: 'guild-1',
+      reply,
+      ...overrides,
+    } as unknown as Message;
+  };
+
+  it('ignores mensajes generados por bots', async () => {
+    const message = createMessage({ author: { id: 'bot-user', bot: true } as never });
+
+    await handleMessageCreate(message);
+
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('ignora mensajes que no tienen prefijo válido', async () => {
+    const message = createMessage({ content: 'hola mundo' });
+
+    await handleMessageCreate(message);
+
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('aplica cooldown y responde cuando corresponde', async () => {
+    const first = createMessage();
+    const second = createMessage();
+
+    await handleMessageCreate(first);
+    await handleMessageCreate(second);
+
+    expect(second.reply).toHaveBeenCalledTimes(1);
+    expect(second.reply).toHaveBeenCalledWith(expect.stringContaining('Debes esperar'));
+  });
+
+  it('bloquea mensajes repetidos considerados spam', async () => {
+    const attempts = [createMessage(), createMessage(), createMessage(), createMessage()];
+
+    await handleMessageCreate(attempts[0]);
+
+    for (let index = 1; index < attempts.length; index += 1) {
+      vi.setSystemTime(new Date(Date.now() + 3_100));
+      await handleMessageCreate(attempts[index]);
+    }
+
+    const finalReply = attempts.at(-1)?.reply;
+    expect(finalReply).toHaveBeenCalledWith(expect.stringContaining('anti-spam'));
+  });
+});

--- a/tests/unit/application/orchestrators/messageDeleteOrchestrator.test.ts
+++ b/tests/unit/application/orchestrators/messageDeleteOrchestrator.test.ts
@@ -1,0 +1,52 @@
+import type { Message, PartialMessage } from 'discord.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { handleMessageDelete } from '@/application/orchestrators/messageDeleteOrchestrator';
+
+vi.mock('@/shared/logger/pino', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const createMessage = (overrides: Partial<Message | PartialMessage> = {}) => ({
+  id: 'message-1',
+  channelId: 'channel-1',
+  guildId: 'guild-1',
+  partial: false,
+  attachments: { size: 0 },
+  ...overrides,
+}) as Message | PartialMessage;
+
+describe('handleMessageDelete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('advierte cuando el mensaje es parcial', async () => {
+    const message = createMessage({ partial: true });
+
+    await handleMessageDelete(message);
+
+    const { logger } = await import('@/shared/logger/pino');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'message-1' }),
+      'Se eliminó un mensaje parcial (sin contenido en caché).',
+    );
+  });
+
+  it('registra la eliminación de mensajes completos', async () => {
+    const message = createMessage({ author: { id: 'user-1' } as never });
+
+    await handleMessageDelete(message);
+
+    const { logger } = await import('@/shared/logger/pino');
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ authorId: 'user-1', hadAttachments: false }),
+      'Mensaje eliminado registrado.',
+    );
+  });
+});

--- a/tests/unit/application/orchestrators/messageReactionAddOrchestrator.test.ts
+++ b/tests/unit/application/orchestrators/messageReactionAddOrchestrator.test.ts
@@ -1,0 +1,54 @@
+import type { MessageReaction, PartialMessageReaction, PartialUser, User } from 'discord.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { handleMessageReactionAdd } from '@/application/orchestrators/messageReactionAddOrchestrator';
+
+vi.mock('@/shared/logger/pino', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const createReaction = (overrides: Partial<MessageReaction | PartialMessageReaction> = {}) => ({
+  emoji: { id: null, name: '🔥' },
+  message: { id: 'message-1', channelId: 'channel-1' },
+  ...overrides,
+}) as MessageReaction | PartialMessageReaction;
+
+const createUser = (overrides: Partial<User | PartialUser> = {}) => ({
+  id: 'user-1',
+  bot: false,
+  ...overrides,
+}) as User | PartialUser;
+
+describe('handleMessageReactionAdd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ignora reacciones generadas por bots', async () => {
+    const reaction = createReaction();
+    const user = createUser({ bot: true });
+
+    await handleMessageReactionAdd(reaction, user);
+
+    const { logger } = await import('@/shared/logger/pino');
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('registra reacciones válidas', async () => {
+    const reaction = createReaction();
+    const user = createUser();
+
+    await handleMessageReactionAdd(reaction, user);
+
+    const { logger } = await import('@/shared/logger/pino');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', emoji: '🔥' }),
+      'Reacción registrada correctamente.',
+    );
+  });
+});

--- a/tests/unit/presentation/events/guildMemberAddEvent.test.ts
+++ b/tests/unit/presentation/events/guildMemberAddEvent.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('discord.js', () => ({
+  Events: { GuildMemberAdd: 'guildMemberAdd' },
+}));
+
+const handleMock = vi.fn();
+
+vi.mock('@/application/orchestrators/guildMemberAddOrchestrator', () => ({
+  handleGuildMemberAdd: handleMock,
+}));
+
+describe('guildMemberAddEvent descriptor', () => {
+  it('invoca al orquestador correspondiente', async () => {
+    const { guildMemberAddEvent } = await import('@/presentation/events/guildMemberAdd');
+
+    await guildMemberAddEvent.execute({} as never);
+
+    expect(handleMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/presentation/events/messageCreateEvent.test.ts
+++ b/tests/unit/presentation/events/messageCreateEvent.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('discord.js', () => ({
+  Events: { MessageCreate: 'messageCreate' },
+}));
+
+const executeMock = vi.fn();
+
+vi.mock('@/application/orchestrators/messageCreateOrchestrator', () => ({
+  handleMessageCreate: executeMock,
+}));
+
+describe('messageCreateEvent descriptor', () => {
+  it('delegates execution al orquestador', async () => {
+    const { messageCreateEvent } = await import('@/presentation/events/messageCreate');
+
+    await messageCreateEvent.execute({} as never);
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/presentation/events/messageDeleteEvent.test.ts
+++ b/tests/unit/presentation/events/messageDeleteEvent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('discord.js', () => ({
+  Events: { MessageDelete: 'messageDelete' },
+}));
+
+const handleMock = vi.fn();
+
+vi.mock('@/application/orchestrators/messageDeleteOrchestrator', () => ({
+  handleMessageDelete: handleMock,
+}));
+
+describe('messageDeleteEvent descriptor', () => {
+  it('delegates la eliminación al orquestador', async () => {
+    const { messageDeleteEvent } = await import('@/presentation/events/messageDelete');
+
+    const message = { id: 'message' } as never;
+
+    await messageDeleteEvent.execute(message);
+
+    expect(handleMock).toHaveBeenCalledWith(message);
+  });
+});

--- a/tests/unit/presentation/events/messageReactionAddEvent.test.ts
+++ b/tests/unit/presentation/events/messageReactionAddEvent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('discord.js', () => ({
+  Events: { MessageReactionAdd: 'messageReactionAdd' },
+}));
+
+const handleMock = vi.fn();
+
+vi.mock('@/application/orchestrators/messageReactionAddOrchestrator', () => ({
+  handleMessageReactionAdd: handleMock,
+}));
+
+describe('messageReactionAddEvent descriptor', () => {
+  it('envía los parámetros a su orquestador', async () => {
+    const { messageReactionAddEvent } = await import('@/presentation/events/messageReactionAdd');
+
+    const reaction = { id: 'reaction' } as never;
+    const user = { id: 'user' } as never;
+
+    await messageReactionAddEvent.execute(reaction, user);
+
+    expect(handleMock).toHaveBeenCalledWith(reaction, user);
+  });
+});


### PR DESCRIPTION
## Summary
- request the additional Discord intents required for member, message and reaction workflows and document the rationale
- add shared guards plus orchestrators for message, reaction and member events and wire them into the presentation layer
- cover the new handlers with Vitest and add deployment guidance for extending the intent matrix

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dddbcafc4883268532cb1038438043