### PR TITLE
feat: implement general ticket workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Campos opcionales:
 - `REDIS_URL` si activas caché o colas
 - `SENTRY_DSN` y `OTEL_EXPORTER_OTLP_ENDPOINT` para observabilidad futura
 
+## 👥 Configuración para el staff
+
+1. Revisa las políticas por tipo en [docs/tickets.md](./docs/tickets.md) y ajusta los límites en la tabla `ticket_type_policies`.
+2. Si necesitas que sólo un rol pueda ver los tickets de cierto tipo, rellena `staff_role_id` con el snowflake del rol de Discord.
+3. Asegúrate de que los moderadores encargados de cierres tengan permisos de **Manage Guild** o **Moderate Members**; el comando `/ticket close`
+   valida estos permisos cuando se utiliza la bandera `staff_override`.
+4. Documenta para el equipo qué información deben solicitar en cada ticket (item, presupuesto, evidencia de pago) para garantizar cierres seguros.
+
 ## 🛠️ Scripts disponibles
 | Script | Descripción |
 | ------ | ----------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 Este directorio albergará la documentación técnica del bot (arquitectura, base de datos, despliegue y catálogo de comandos). Se irá llenando en las siguientes fases.
 
 - [Guía de intents](./intents.md): pasos para adaptar la matriz de intents según el entorno de despliegue.
+- [Matriz de tickets](./tickets.md): políticas, límites y permisos requeridos para el sistema de tickets generales.

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -1,0 +1,45 @@
+# Matriz de tickets generales
+
+El bot gestiona los tickets generales mediante la tabla `ticket_type_policies`, que define límites por usuario y ventanas de cooldown.
+Cada registro se enlaza con el catálogo `ticket_types` y controla el flujo de los casos de uso `OpenGeneralTicketUseCase`, `CloseGeneralTicketUseCase`
+y `ListUserTicketsUseCase`.
+
+| Tipo | Uso habitual | Máx. tickets simultáneos | Cooldown | ¿Requiere staff? | Notas |
+| ---- | ------------ | ------------------------ | -------- | ---------------- | ----- |
+| `BUY` | Solicitudes de compra de ítems/servicios. | 2 | 60 minutos | No | Recomendado pedir contexto detallado para evitar estafas. |
+| `SELL` | Ofertas de venta dentro del servidor. | 2 | 60 minutos | No | Se sugiere habilitar middleman cuando sea posible. |
+| `ROBUX` | Compras/ventas de Robux. | 1 | 120 minutos | Sí (revisión) | Sólo personal verificado puede aprobar y cerrar si no participa. |
+| `NITRO` | Gestión de regalos o compras de Nitro. | 1 | 120 minutos | No | Validar capturas de pago antes de cerrar. |
+| `DECOR` | Encargos de builds/decoraciones. | 1 | 180 minutos | No | Priorizar canales de seguimiento para entregas largas. |
+
+> **Nota:** Las ventanas de cooldown se expresan en segundos en la base de datos (3600 = 1 hora). Los valores anteriores corresponden a las
+> inserciones declaradas en [`sql/schema.sql`](../sql/schema.sql), pero pueden ajustarse a la operativa del servidor.
+
+## Configuración de políticas
+
+1. Asegúrate de que las tablas `ticket_types`, `ticket_type_policies` y `ticket_type_cooldowns` existan en tu instancia MySQL (se crean
+   automáticamente al ejecutar el `schema.sql`).
+2. Actualiza los límites ejecutando el siguiente comando en MySQL:
+
+```sql
+INSERT INTO ticket_type_policies (type_id, max_open_per_user, cooldown_seconds, staff_role_id, requires_staff_approval)
+VALUES (3, 1, 5400, NULL, 1)
+ON DUPLICATE KEY UPDATE
+  max_open_per_user = VALUES(max_open_per_user),
+  cooldown_seconds = VALUES(cooldown_seconds),
+  staff_role_id = VALUES(staff_role_id),
+  requires_staff_approval = VALUES(requires_staff_approval);
+```
+
+3. Si deseas restringir la visibilidad a un rol de Discord específico, rellena la columna `staff_role_id` con el snowflake del rol.
+4. El caso de uso de apertura validará que el usuario no tenga más tickets abiertos del tipo seleccionado y que haya expirado el cooldown.
+
+## Mapeo de permisos
+
+- **Staff estándar (`requires_staff_approval = 0`)**: cualquier usuario puede abrir tickets y el personal moderador puede cerrarlos si participa.
+- **Staff con revisión (`requires_staff_approval = 1`)**: al cerrar desde el comando `/ticket close` es necesario contar con permisos de
+  `ManageGuild` o `ModerateMembers` y activar la bandera `staff_override`.
+- **Participantes adicionales**: el comando añade automáticamente al propietario y a la contraparte indicada en el formulario. Otros usuarios
+  deben añadirse manualmente desde Discord antes de ejecutar el cierre.
+
+Mantén este documento sincronizado cuando ajustes las políticas para que el equipo de moderación conozca los límites vigentes.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,30 @@ enum TicketStatus {
   CLOSED
 }
 
+model TicketTypePolicy {
+  type                 TicketType @id
+  maxOpenPerUser       Int        @map("max_open_per_user")
+  cooldownSeconds      Int        @map("cooldown_seconds")
+  staffRoleId          BigInt?    @map("staff_role_id")
+  requiresStaffApproval Boolean   @default(false) @map("requires_staff_approval")
+
+  cooldowns TicketTypeCooldown[]
+
+  @@map("ticket_type_policies")
+}
+
+model TicketTypeCooldown {
+  type         TicketType @map("type")
+  userId       BigInt     @map("user_id")
+  lastOpenedAt DateTime   @default(now()) @map("last_opened_at")
+
+  policy TicketTypePolicy @relation(fields: [type], references: [type], onDelete: Cascade)
+
+  @@id([type, userId])
+  @@index([userId])
+  @@map("ticket_type_cooldowns")
+}
+
 enum TradeStatus {
   PENDING
   ACTIVE

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -98,6 +98,38 @@ CREATE TABLE ticket_participants (
   CONSTRAINT fk_tp_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
+CREATE TABLE ticket_type_policies (
+  type_id TINYINT UNSIGNED PRIMARY KEY,
+  max_open_per_user INT NOT NULL DEFAULT 1,
+  cooldown_seconds INT NOT NULL DEFAULT 0,
+  staff_role_id BIGINT UNSIGNED NULL,
+  requires_staff_approval TINYINT(1) NOT NULL DEFAULT 0,
+  CONSTRAINT fk_policy_type FOREIGN KEY (type_id) REFERENCES ticket_types(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE ticket_type_cooldowns (
+  type_id TINYINT UNSIGNED NOT NULL,
+  user_id BIGINT UNSIGNED NOT NULL,
+  last_opened_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (type_id, user_id),
+  INDEX idx_cooldown_user (user_id),
+  CONSTRAINT fk_cooldown_type FOREIGN KEY (type_id) REFERENCES ticket_type_policies(type_id) ON DELETE CASCADE,
+  CONSTRAINT fk_cooldown_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+INSERT INTO ticket_type_policies (type_id, max_open_per_user, cooldown_seconds, staff_role_id, requires_staff_approval)
+VALUES
+  (1, 2, 3600, NULL, 0),
+  (2, 2, 3600, NULL, 0),
+  (3, 1, 7200, NULL, 1),
+  (4, 1, 7200, NULL, 0),
+  (5, 1, 10800, NULL, 0)
+ON DUPLICATE KEY UPDATE
+  max_open_per_user = VALUES(max_open_per_user),
+  cooldown_seconds = VALUES(cooldown_seconds),
+  staff_role_id = VALUES(staff_role_id),
+  requires_staff_approval = VALUES(requires_staff_approval);
+
 -- =========================================
 -- Middlemen
 -- =========================================

--- a/src/application/dto/ticket.dto.ts
+++ b/src/application/dto/ticket.dto.ts
@@ -4,6 +4,116 @@
 
 import { z } from 'zod';
 
+const DiscordSnowflakeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{17,20}$/u, 'Invalid Discord ID');
+
+const GuildSnowflakeSchema = DiscordSnowflakeSchema.describe('Discord guild snowflake');
+
+const PositiveIntegerSchema = z
+  .coerce
+  .number()
+  .int('Value must be a positive integer')
+  .positive('Value must be a positive integer');
+
+const TrimmedString = z.string().trim();
+
+const RichDescriptionSchema = TrimmedString.min(20, 'Context must include at least 20 characters.').max(
+  1_000,
+  'Context must be at most 1000 characters.',
+);
+
+const ShortLabelSchema = TrimmedString.min(3, 'Provide a longer description.').max(80, 'Label is too long.');
+
+export const GeneralTicketTypeSchema = z.enum(['BUY', 'SELL', 'ROBUX', 'NITRO', 'DECOR']);
+export type GeneralTicketType = z.infer<typeof GeneralTicketTypeSchema>;
+
+const BaseGeneralTicketSchema = z.object({
+  userId: DiscordSnowflakeSchema,
+  guildId: GuildSnowflakeSchema,
+  partnerId: DiscordSnowflakeSchema.optional(),
+  referenceMessageUrl: TrimmedString.url('Reference must be a valid Discord message URL.').optional(),
+});
+
+const AmountSchema = PositiveIntegerSchema.max(10_000_000, 'Amount exceeds supported range.');
+
+const BuyTicketContextSchema = z.object({
+  item: ShortLabelSchema,
+  quantity: PositiveIntegerSchema.max(1_000, 'Quantity too large.').optional(),
+  budgetRobux: AmountSchema.optional(),
+  notes: RichDescriptionSchema,
+});
+
+const SellTicketContextSchema = z.object({
+  item: ShortLabelSchema,
+  quantity: PositiveIntegerSchema.max(1_000, 'Quantity too large.').optional(),
+  priceRobux: AmountSchema.optional(),
+  acceptsMiddleman: z.boolean().default(true),
+  notes: RichDescriptionSchema,
+});
+
+const RobuxTicketContextSchema = z.object({
+  amount: AmountSchema.min(100, 'The minimum trade amount is 100 Robux.'),
+  paymentMethod: TrimmedString.min(3).max(40),
+  notes: RichDescriptionSchema,
+});
+
+const NitroTicketContextSchema = z.object({
+  plan: z.enum(['CLASSIC', 'BOOST', 'GIFT']).default('BOOST'),
+  months: PositiveIntegerSchema.max(24, 'Nitro duration must be <= 24 months.').optional(),
+  notes: RichDescriptionSchema,
+});
+
+const DecorTicketContextSchema = z.object({
+  asset: ShortLabelSchema,
+  theme: TrimmedString.min(3).max(60).optional(),
+  notes: RichDescriptionSchema,
+});
+
+export const CreateGeneralTicketSchema = z.discriminatedUnion('type', [
+  BaseGeneralTicketSchema.extend({
+    type: z.literal('BUY'),
+    context: BuyTicketContextSchema,
+  }),
+  BaseGeneralTicketSchema.extend({
+    type: z.literal('SELL'),
+    context: SellTicketContextSchema,
+  }),
+  BaseGeneralTicketSchema.extend({
+    type: z.literal('ROBUX'),
+    context: RobuxTicketContextSchema,
+  }),
+  BaseGeneralTicketSchema.extend({
+    type: z.literal('NITRO'),
+    context: NitroTicketContextSchema,
+  }),
+  BaseGeneralTicketSchema.extend({
+    type: z.literal('DECOR'),
+    context: DecorTicketContextSchema,
+  }),
+]);
+
+export type CreateGeneralTicketDTO = z.infer<typeof CreateGeneralTicketSchema>;
+
+export const CloseGeneralTicketSchema = z.object({
+  ticketId: z.number().int().positive(),
+  executorId: DiscordSnowflakeSchema,
+  reason: TrimmedString.max(500, 'Reason must not exceed 500 characters.').optional(),
+  allowStaffOverride: z.boolean().optional(),
+});
+
+export type CloseGeneralTicketDTO = z.infer<typeof CloseGeneralTicketSchema>;
+
+export const ListUserTicketsSchema = z.object({
+  userId: DiscordSnowflakeSchema,
+  guildId: GuildSnowflakeSchema,
+  includeClosed: z.boolean().optional(),
+  limit: PositiveIntegerSchema.max(25).default(10),
+});
+
+export type ListUserTicketsDTO = z.infer<typeof ListUserTicketsSchema>;
+
 export const CreateMiddlemanTicketSchema = z.object({
   userId: z.string().regex(/^\d+$/u, 'Invalid Discord ID'),
   guildId: z.string().regex(/^\d+$/u, 'Invalid guild ID'),

--- a/src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
+++ b/src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
@@ -1,0 +1,58 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
+// =============================================================================
+
+import {
+  type CloseGeneralTicketDTO,
+  CloseGeneralTicketSchema,
+} from '@/application/dto/ticket.dto';
+import { TicketType } from '@/domain/entities/types';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import {
+  TicketClosedError,
+  TicketNotFoundError,
+  TicketParticipantNotFoundError,
+  UnauthorizedActionError,
+} from '@/shared/errors/domain.errors';
+import type { Logger } from '@/shared/logger/pino';
+
+export class CloseGeneralTicketUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly participantRepo: ITicketParticipantRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  public async execute(dto: CloseGeneralTicketDTO): Promise<void> {
+    const payload = CloseGeneralTicketSchema.parse(dto);
+    const ticket = await this.ticketRepo.findById(payload.ticketId);
+
+    if (!ticket) {
+      throw new TicketNotFoundError(String(payload.ticketId));
+    }
+
+    if (ticket.type === TicketType.MM) {
+      throw new UnauthorizedActionError('ticket:general:close:unsupported-type');
+    }
+
+    if (ticket.isClosed()) {
+      throw new TicketClosedError(ticket.id);
+    }
+
+    const executorId = BigInt(payload.executorId);
+    const isParticipant = await this.participantRepo.isParticipant(ticket.id, executorId);
+
+    if (!isParticipant && !payload.allowStaffOverride) {
+      throw new TicketParticipantNotFoundError(ticket.id, payload.executorId);
+    }
+
+    ticket.close();
+    await this.ticketRepo.update(ticket);
+
+    this.logger.info(
+      { ticketId: ticket.id, executorId: payload.executorId },
+      'Ticket general cerrado correctamente.',
+    );
+  }
+}

--- a/src/application/usecases/tickets/ListUserTicketsUseCase.ts
+++ b/src/application/usecases/tickets/ListUserTicketsUseCase.ts
@@ -1,0 +1,34 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/ListUserTicketsUseCase.ts
+// =============================================================================
+
+import {
+  type ListUserTicketsDTO,
+  ListUserTicketsSchema,
+} from '@/application/dto/ticket.dto';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+
+const OPEN_STATUSES: readonly TicketStatus[] = [
+  TicketStatus.OPEN,
+  TicketStatus.CONFIRMED,
+  TicketStatus.CLAIMED,
+];
+
+export class ListUserTicketsUseCase {
+  public constructor(private readonly ticketRepo: ITicketRepository) {}
+
+  public async execute(dto: ListUserTicketsDTO) {
+    const payload = ListUserTicketsSchema.parse(dto);
+    const ownerId = BigInt(payload.userId);
+    const guildId = BigInt(payload.guildId);
+
+    const tickets = await this.ticketRepo.findByOwner(ownerId, {
+      guildId,
+      statuses: payload.includeClosed ? undefined : [...OPEN_STATUSES],
+      limit: payload.limit,
+    });
+
+    return tickets.filter((ticket) => ticket.type !== TicketType.MM);
+  }
+}

--- a/src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
+++ b/src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
@@ -1,0 +1,249 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
+// =============================================================================
+
+import type { PrismaClient } from '@prisma/client';
+import type { Guild, TextChannel } from 'discord.js';
+import { ChannelType, PermissionFlagsBits } from 'discord.js';
+import type { Logger } from 'pino';
+
+import {
+  type CreateGeneralTicketDTO,
+  CreateGeneralTicketSchema,
+} from '@/application/dto/ticket.dto';
+import { TicketType } from '@/domain/entities/types';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import type {
+  ITicketRepository,
+  TicketParticipantInput,
+} from '@/domain/repositories/ITicketRepository';
+import type { ITicketTypePolicyRepository } from '@/domain/repositories/ITicketTypePolicyRepository';
+import type { EmbedFactory } from '@/presentation/embeds/EmbedFactory';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import {
+  ChannelCleanupError,
+  ChannelCreationError,
+  TicketCooldownActiveError,
+  TicketPolicyNotFoundError,
+  TooManyOpenTicketsError,
+} from '@/shared/errors/domain.errors';
+import { sanitizeChannelName } from '@/shared/utils/discord.utils';
+
+const formatContext = (payload: CreateGeneralTicketDTO): string => {
+  const lines: string[] = [];
+
+  switch (payload.type) {
+    case 'BUY':
+      lines.push(`**Artículo:** ${payload.context.item}`);
+      if (payload.context.quantity) {
+        lines.push(`**Cantidad:** ${payload.context.quantity}`);
+      }
+      if (payload.context.budgetRobux) {
+        lines.push(`**Presupuesto:** ${payload.context.budgetRobux.toLocaleString()} Robux`);
+      }
+      break;
+    case 'SELL':
+      lines.push(`**Artículo:** ${payload.context.item}`);
+      if (payload.context.quantity) {
+        lines.push(`**Cantidad:** ${payload.context.quantity}`);
+      }
+      if (payload.context.priceRobux) {
+        lines.push(`**Precio:** ${payload.context.priceRobux.toLocaleString()} Robux`);
+      }
+      lines.push(`**Acepta middleman:** ${payload.context.acceptsMiddleman ? 'Sí' : 'No'}`);
+      break;
+    case 'ROBUX':
+      lines.push(`**Cantidad:** ${payload.context.amount.toLocaleString()} Robux`);
+      lines.push(`**Pago:** ${payload.context.paymentMethod}`);
+      break;
+    case 'NITRO':
+      lines.push(`**Plan:** ${payload.context.plan}`);
+      if (payload.context.months) {
+        lines.push(`**Duración:** ${payload.context.months} meses`);
+      }
+      break;
+    case 'DECOR':
+      lines.push(`**Asset:** ${payload.context.asset}`);
+      if (payload.context.theme) {
+        lines.push(`**Tema:** ${payload.context.theme}`);
+      }
+      break;
+    default:
+      break;
+  }
+
+  const notes = payload.context.notes ?? '';
+  if (notes) {
+    lines.push('', notes);
+  }
+
+  if (payload.referenceMessageUrl) {
+    lines.push('', `[Mensaje de referencia](${payload.referenceMessageUrl})`);
+  }
+
+  return lines.join('\n');
+};
+
+export class OpenGeneralTicketUseCase {
+  public constructor(
+    private readonly prisma: PrismaClient,
+    private readonly ticketRepo: ITicketRepository,
+    private readonly participantRepo: ITicketParticipantRepository,
+    private readonly policyRepo: ITicketTypePolicyRepository,
+    private readonly logger: Logger,
+    private readonly embeds: EmbedFactory = embedFactory,
+  ) {}
+
+  public async execute(
+    dto: CreateGeneralTicketDTO,
+    guild: Guild,
+  ): Promise<{ ticket: Awaited<ReturnType<ITicketRepository['create']>>; channel: TextChannel }> {
+    const payload = CreateGeneralTicketSchema.parse(dto);
+    const ownerId = BigInt(payload.userId);
+    const guildId = BigInt(payload.guildId);
+    const ticketType = TicketType[payload.type as keyof typeof TicketType];
+
+    const policy = await this.policyRepo.getPolicy(ticketType);
+    if (!policy) {
+      throw new TicketPolicyNotFoundError(payload.type);
+    }
+
+    this.logger.debug({ ownerId: payload.userId, type: payload.type }, 'Verificando límite de tickets.');
+    const openTickets = await this.ticketRepo.countOpenByOwnerAndType(ownerId, ticketType);
+    if (openTickets >= policy.maxOpenPerUser) {
+      throw new TooManyOpenTicketsError(policy.maxOpenPerUser);
+    }
+
+    const now = new Date();
+    const cooldown = await this.policyRepo.getCooldown(ticketType, ownerId);
+    if (cooldown) {
+      const elapsedSeconds = Math.floor((now.getTime() - cooldown.lastOpenedAt.getTime()) / 1_000);
+      const remainingSeconds = policy.cooldownSeconds - elapsedSeconds;
+      if (remainingSeconds > 0) {
+        throw new TicketCooldownActiveError(payload.type, remainingSeconds);
+      }
+    }
+
+    const botId = guild.members.me?.id;
+    if (!botId) {
+      throw new ChannelCreationError('El bot no está presente en el gremio.');
+    }
+
+    const channelName = sanitizeChannelName(`${payload.type.toLowerCase()}-${payload.userId}`);
+    const topic = payload.context.notes?.slice(0, 100) ?? `${payload.type} ticket`; // short topic
+
+    this.logger.debug({ channelName, guildId: payload.guildId }, 'Creando canal de ticket general.');
+
+    let createdChannel: TextChannel;
+    try {
+      createdChannel = await guild.channels.create({
+        name: channelName,
+        type: ChannelType.GuildText,
+        topic,
+        permissionOverwrites: [
+          { id: guild.roles.everyone.id, deny: [PermissionFlagsBits.ViewChannel] },
+          {
+            id: payload.userId,
+            allow: [
+              PermissionFlagsBits.ViewChannel,
+              PermissionFlagsBits.SendMessages,
+              PermissionFlagsBits.ReadMessageHistory,
+            ],
+          },
+          {
+            id: botId,
+            allow: [
+              PermissionFlagsBits.ViewChannel,
+              PermissionFlagsBits.SendMessages,
+              PermissionFlagsBits.ManageChannels,
+              PermissionFlagsBits.ReadMessageHistory,
+            ],
+          },
+        ],
+      });
+
+      if (policy.staffRoleId) {
+        await createdChannel.permissionOverwrites.edit(String(policy.staffRoleId), {
+          ViewChannel: true,
+          SendMessages: true,
+          ReadMessageHistory: true,
+        });
+      }
+
+      if (payload.partnerId) {
+        await createdChannel.permissionOverwrites.edit(payload.partnerId, {
+          ViewChannel: true,
+          SendMessages: true,
+          ReadMessageHistory: true,
+        });
+      }
+    } catch (error) {
+      this.logger.error({ err: error, channelName }, 'Falló la creación del canal de ticket general.');
+      throw new ChannelCreationError((error as Error).message);
+    }
+
+    try {
+      const ticket = await this.prisma.$transaction(async (tx) => {
+        const transactionalTicketRepo = this.ticketRepo.withTransaction(tx);
+        const transactionalParticipantRepo = this.participantRepo.withTransaction(tx);
+        const transactionalPolicyRepo = this.policyRepo.withTransaction(tx);
+
+        const createdTicket = await transactionalTicketRepo.create({
+          guildId,
+          channelId: BigInt(createdChannel.id),
+          ownerId,
+          type: ticketType,
+        });
+
+        const participants: TicketParticipantInput[] = [{ userId: ownerId, role: 'OWNER' }];
+        if (payload.partnerId) {
+          participants.push({ userId: BigInt(payload.partnerId), role: 'PARTNER' });
+        }
+
+        await transactionalParticipantRepo.addMany(createdTicket.id, participants);
+        await transactionalPolicyRepo.upsertCooldown(ticketType, ownerId, now);
+
+        return createdTicket;
+      });
+
+      const contextSummary = formatContext(payload);
+      const mentionParts = [`<@${payload.userId}>`];
+      if (payload.partnerId) {
+        mentionParts.push(`<@${payload.partnerId}>`);
+      }
+
+      await createdChannel.send({
+        content: mentionParts.join(' '),
+        embeds: [
+          this.embeds.ticketCreated({
+            ticketId: ticket.id,
+            type: `General · ${payload.type}`,
+            ownerTag: `<@${payload.userId}>`,
+            description: contextSummary,
+          }),
+        ],
+      });
+
+      this.logger.info(
+        { ticketId: ticket.id, channelId: createdChannel.id, ownerId: payload.userId, type: payload.type },
+        'Ticket general creado exitosamente.',
+      );
+
+      return { ticket, channel: createdChannel };
+    } catch (error) {
+      this.logger.error({ err: error, ownerId: payload.userId }, 'Fallo al persistir ticket general.');
+
+      try {
+        await createdChannel.delete('Error al registrar el ticket general.');
+      } catch (cleanupError) {
+        this.logger.error(
+          { err: cleanupError, channelId: createdChannel.id },
+          'Fallo al limpiar canal de ticket general tras error.',
+        );
+        throw new ChannelCleanupError(createdChannel.id, cleanupError);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/domain/entities/Ticket.ts
+++ b/src/domain/entities/Ticket.ts
@@ -2,8 +2,7 @@
 // RUTA: src/domain/entities/Ticket.ts
 // ============================================================================
 
-import type { TicketType } from '@/domain/entities/types';
-import { TicketStatus } from '@/domain/entities/types';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
 import { InvalidTicketStateError } from '@/shared/errors/domain.errors';
 
 export class Ticket {
@@ -24,7 +23,11 @@ export class Ticket {
   }
 
   public canBeClosed(): boolean {
-    return this.status === TicketStatus.CLAIMED || this.status === TicketStatus.CONFIRMED;
+    if (this.type === TicketType.MM) {
+      return this.status === TicketStatus.CLAIMED || this.status === TicketStatus.CONFIRMED;
+    }
+
+    return this.status !== TicketStatus.CLOSED;
   }
 
   public claim(middlemanId: bigint): void {

--- a/src/domain/repositories/ITicketParticipantRepository.ts
+++ b/src/domain/repositories/ITicketParticipantRepository.ts
@@ -1,0 +1,21 @@
+// =============================================================================
+// RUTA: src/domain/repositories/ITicketParticipantRepository.ts
+// =============================================================================
+
+import type { TicketParticipantInput } from '@/domain/repositories/ITicketRepository';
+import type { Transactional } from '@/domain/repositories/transaction';
+
+export interface TicketParticipantRecord {
+  readonly ticketId: number;
+  readonly userId: bigint;
+  readonly role: string | null;
+  readonly joinedAt: Date;
+}
+
+export interface ITicketParticipantRepository
+  extends Transactional<ITicketParticipantRepository> {
+  addMany(ticketId: number, participants: ReadonlyArray<TicketParticipantInput>): Promise<void>;
+  remove(ticketId: number, userId: bigint): Promise<void>;
+  list(ticketId: number): Promise<readonly TicketParticipantRecord[]>;
+  isParticipant(ticketId: number, userId: bigint): Promise<boolean>;
+}

--- a/src/domain/repositories/ITicketRepository.ts
+++ b/src/domain/repositories/ITicketRepository.ts
@@ -21,13 +21,22 @@ export interface CreateTicketData {
   readonly participants?: ReadonlyArray<TicketParticipantInput>;
 }
 
+export interface FindTicketsByOwnerOptions {
+  readonly statuses?: ReadonlyArray<TicketStatus>;
+  readonly type?: TicketType;
+  readonly limit?: number;
+  readonly guildId?: bigint;
+}
+
 export interface ITicketRepository extends Transactional<ITicketRepository> {
   create(data: CreateTicketData): Promise<Ticket>;
   findById(id: number): Promise<Ticket | null>;
   findByChannelId(channelId: bigint): Promise<Ticket | null>;
   findOpenByOwner(ownerId: bigint): Promise<readonly Ticket[]>;
+  findByOwner(ownerId: bigint, options?: FindTicketsByOwnerOptions): Promise<readonly Ticket[]>;
   update(ticket: Ticket): Promise<void>;
   delete(id: number): Promise<void>;
   countOpenByOwner(ownerId: bigint): Promise<number>;
+  countOpenByOwnerAndType(ownerId: bigint, type: TicketType): Promise<number>;
   isParticipant(ticketId: number, userId: bigint): Promise<boolean>;
 }

--- a/src/domain/repositories/ITicketTypePolicyRepository.ts
+++ b/src/domain/repositories/ITicketTypePolicyRepository.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// RUTA: src/domain/repositories/ITicketTypePolicyRepository.ts
+// =============================================================================
+
+import type { TicketType } from '@/domain/entities/types';
+import type { Transactional } from '@/domain/repositories/transaction';
+
+export interface TicketTypePolicy {
+  readonly type: TicketType;
+  readonly maxOpenPerUser: number;
+  readonly cooldownSeconds: number;
+  readonly staffRoleId?: bigint;
+  readonly requiresStaffApproval: boolean;
+}
+
+export interface TicketTypeCooldown {
+  readonly type: TicketType;
+  readonly userId: bigint;
+  readonly lastOpenedAt: Date;
+}
+
+export interface ITicketTypePolicyRepository
+  extends Transactional<ITicketTypePolicyRepository> {
+  getPolicy(type: TicketType): Promise<TicketTypePolicy | null>;
+  getAllPolicies(): Promise<readonly TicketTypePolicy[]>;
+  getCooldown(type: TicketType, userId: bigint): Promise<TicketTypeCooldown | null>;
+  upsertCooldown(type: TicketType, userId: bigint, openedAt: Date): Promise<void>;
+}

--- a/src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
@@ -1,0 +1,89 @@
+// =============================================================================
+// RUTA: src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
+// =============================================================================
+
+import type {
+  Prisma,
+  PrismaClient,
+  TicketParticipant as PrismaTicketParticipantModel,
+} from '@prisma/client';
+
+import type { ITicketParticipantRepository, TicketParticipantRecord } from '@/domain/repositories/ITicketParticipantRepository';
+import type { TicketParticipantInput } from '@/domain/repositories/ITicketRepository';
+import type { TransactionContext } from '@/domain/repositories/transaction';
+
+const mapParticipantInput = (ticketId: number, participant: TicketParticipantInput) => ({
+  ticketId,
+  userId: participant.userId,
+  role: participant.role ?? null,
+  joinedAt: participant.joinedAt ?? new Date(),
+});
+
+const mapRecord = (participant: PrismaTicketParticipantModel): TicketParticipantRecord => ({
+  ticketId: participant.ticketId,
+  userId: participant.userId,
+  role: participant.role,
+  joinedAt: participant.joinedAt,
+});
+
+type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
+
+export class PrismaTicketParticipantRepository implements ITicketParticipantRepository {
+  public constructor(private readonly prisma: PrismaClientLike) {}
+
+  public withTransaction(context: TransactionContext): ITicketParticipantRepository {
+    if (!PrismaTicketParticipantRepository.isTransactionClient(context)) {
+      throw new Error('Invalid Prisma transaction context provided to ticket participant repository.');
+    }
+
+    return new PrismaTicketParticipantRepository(context);
+  }
+
+  public async addMany(ticketId: number, participants: ReadonlyArray<TicketParticipantInput>): Promise<void> {
+    if (participants.length === 0) {
+      return;
+    }
+
+    await this.prisma.ticketParticipant.createMany({
+      data: participants.map((participant) => mapParticipantInput(ticketId, participant)),
+      skipDuplicates: true,
+    });
+  }
+
+  public async remove(ticketId: number, userId: bigint): Promise<void> {
+    await this.prisma.ticketParticipant.delete({
+      where: {
+        ticketId_userId: {
+          ticketId,
+          userId,
+        },
+      },
+    });
+  }
+
+  public async list(ticketId: number): Promise<readonly TicketParticipantRecord[]> {
+    const participants = await this.prisma.ticketParticipant.findMany({
+      where: { ticketId },
+      orderBy: { joinedAt: 'asc' },
+    });
+
+    return participants.map(mapRecord);
+  }
+
+  public async isParticipant(ticketId: number, userId: bigint): Promise<boolean> {
+    const participant = await this.prisma.ticketParticipant.findUnique({
+      where: {
+        ticketId_userId: {
+          ticketId,
+          userId,
+        },
+      },
+    });
+
+    return participant !== null;
+  }
+
+  private static isTransactionClient(value: TransactionContext): value is Prisma.TransactionClient {
+    return typeof value === 'object' && value !== null && 'ticketParticipant' in value;
+  }
+}

--- a/src/infrastructure/repositories/PrismaTicketTypePolicyRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketTypePolicyRepository.ts
@@ -1,0 +1,95 @@
+// =============================================================================
+// RUTA: src/infrastructure/repositories/PrismaTicketTypePolicyRepository.ts
+// =============================================================================
+
+import type {
+  Prisma,
+  PrismaClient,
+  TicketTypePolicy as PrismaTicketTypePolicyModel,
+  TicketTypeCooldown as PrismaTicketTypeCooldownModel,
+} from '@prisma/client';
+
+import type { TicketType } from '@/domain/entities/types';
+import type {
+  ITicketTypePolicyRepository,
+  TicketTypeCooldown,
+  TicketTypePolicy,
+} from '@/domain/repositories/ITicketTypePolicyRepository';
+import type { TransactionContext } from '@/domain/repositories/transaction';
+
+const mapPolicy = (policy: PrismaTicketTypePolicyModel): TicketTypePolicy => ({
+  type: policy.type as TicketType,
+  maxOpenPerUser: policy.maxOpenPerUser,
+  cooldownSeconds: policy.cooldownSeconds,
+  staffRoleId: policy.staffRoleId ?? undefined,
+  requiresStaffApproval: policy.requiresStaffApproval,
+});
+
+const mapCooldown = (cooldown: PrismaTicketTypeCooldownModel): TicketTypeCooldown => ({
+  type: cooldown.type as TicketType,
+  userId: cooldown.userId,
+  lastOpenedAt: cooldown.lastOpenedAt,
+});
+
+type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
+
+export class PrismaTicketTypePolicyRepository implements ITicketTypePolicyRepository {
+  public constructor(private readonly prisma: PrismaClientLike) {}
+
+  public withTransaction(context: TransactionContext): ITicketTypePolicyRepository {
+    if (!PrismaTicketTypePolicyRepository.isTransactionClient(context)) {
+      throw new Error('Invalid Prisma transaction context provided to ticket type policy repository.');
+    }
+
+    return new PrismaTicketTypePolicyRepository(context);
+  }
+
+  public async getPolicy(type: TicketType): Promise<TicketTypePolicy | null> {
+    const policy = await this.prisma.ticketTypePolicy.findUnique({
+      where: { type },
+    });
+
+    return policy ? mapPolicy(policy) : null;
+  }
+
+  public async getAllPolicies(): Promise<readonly TicketTypePolicy[]> {
+    const policies = await this.prisma.ticketTypePolicy.findMany();
+    return policies.map(mapPolicy);
+  }
+
+  public async getCooldown(type: TicketType, userId: bigint): Promise<TicketTypeCooldown | null> {
+    const cooldown = await this.prisma.ticketTypeCooldown.findUnique({
+      where: {
+        type_userId: {
+          type,
+          userId,
+        },
+      },
+    });
+
+    return cooldown ? mapCooldown(cooldown) : null;
+  }
+
+  public async upsertCooldown(type: TicketType, userId: bigint, openedAt: Date): Promise<void> {
+    await this.prisma.ticketTypeCooldown.upsert({
+      where: {
+        type_userId: {
+          type,
+          userId,
+        },
+      },
+      create: {
+        type,
+        userId,
+        lastOpenedAt: openedAt,
+      },
+      update: {
+        lastOpenedAt: openedAt,
+      },
+    });
+  }
+
+  private static isTransactionClient(value: TransactionContext): value is Prisma.TransactionClient {
+    return typeof value === 'object' && value !== null && 'ticketTypePolicy' in value;
+  }
+}

--- a/src/presentation/commands/index.ts
+++ b/src/presentation/commands/index.ts
@@ -6,9 +6,10 @@ import { commandRegistry, getRegisteredCommands, registerCommands, serializeComm
 import { helpCommand } from '@/presentation/commands/general/help';
 import { pingCommand } from '@/presentation/commands/general/ping';
 import { middlemanCommand } from '@/presentation/commands/middleman/middleman';
+import { ticketCommand } from '@/presentation/commands/tickets/ticket';
 import type { Command } from '@/presentation/commands/types';
 
-const commands: Command[] = [pingCommand, helpCommand, middlemanCommand];
+const commands: Command[] = [pingCommand, helpCommand, middlemanCommand, ticketCommand];
 
 registerCommands(commands);
 

--- a/src/presentation/commands/tickets/ticket.ts
+++ b/src/presentation/commands/tickets/ticket.ts
@@ -1,0 +1,415 @@
+// =============================================================================
+// RUTA: src/presentation/commands/tickets/ticket.ts
+// =============================================================================
+
+import {
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  ChannelType,
+  PermissionFlagsBits,
+} from 'discord.js';
+
+import {
+  type CloseGeneralTicketDTO,
+  type CreateGeneralTicketDTO,
+  type ListUserTicketsDTO,
+} from '@/application/dto/ticket.dto';
+import { CloseGeneralTicketUseCase } from '@/application/usecases/tickets/CloseGeneralTicketUseCase';
+import { ListUserTicketsUseCase } from '@/application/usecases/tickets/ListUserTicketsUseCase';
+import { OpenGeneralTicketUseCase } from '@/application/usecases/tickets/OpenGeneralTicketUseCase';
+import { prisma } from '@/infrastructure/db/prisma';
+import { PrismaTicketParticipantRepository } from '@/infrastructure/repositories/PrismaTicketParticipantRepository';
+import { PrismaTicketRepository } from '@/infrastructure/repositories/PrismaTicketRepository';
+import { PrismaTicketTypePolicyRepository } from '@/infrastructure/repositories/PrismaTicketTypePolicyRepository';
+import { TicketShortcutSelect } from '@/presentation/components/selects/TicketShortcutSelect';
+import type { Command } from '@/presentation/commands/types';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import { UnauthorizedActionError } from '@/shared/errors/domain.errors';
+import { logger } from '@/shared/logger/pino';
+
+const ticketRepo = new PrismaTicketRepository(prisma);
+const participantRepo = new PrismaTicketParticipantRepository(prisma);
+const policyRepo = new PrismaTicketTypePolicyRepository(prisma);
+
+const openUseCase = new OpenGeneralTicketUseCase(
+  prisma,
+  ticketRepo,
+  participantRepo,
+  policyRepo,
+  logger,
+  embedFactory,
+);
+const closeUseCase = new CloseGeneralTicketUseCase(ticketRepo, participantRepo, logger);
+const listUseCase = new ListUserTicketsUseCase(ticketRepo);
+
+const TYPES: ReadonlyArray<{ name: string; value: string }> = [
+  { name: 'Comprar', value: 'BUY' },
+  { name: 'Vender', value: 'SELL' },
+  { name: 'Robux', value: 'ROBUX' },
+  { name: 'Nitro', value: 'NITRO' },
+  { name: 'Decor/Builds', value: 'DECOR' },
+];
+
+const ensureGuildInteraction = (interaction: ChatInputCommandInteraction) => {
+  if (!interaction.guild || interaction.channel?.type !== ChannelType.GuildText) {
+    throw new UnauthorizedActionError('tickets:command:guild-only');
+  }
+
+  return interaction.guild;
+};
+
+const buildOpenDto = (interaction: ChatInputCommandInteraction): CreateGeneralTicketDTO => {
+  const type = interaction.options.getString('type', true).toUpperCase();
+  const summary = interaction.options.getString('summary', true).trim();
+  const notes = interaction.options.getString('notes', true).trim();
+  const partner = interaction.options.getUser('partner');
+  const reference = interaction.options.getString('reference') ?? undefined;
+
+  switch (type) {
+    case 'BUY':
+      return {
+        type: 'BUY',
+        userId: interaction.user.id,
+        guildId: interaction.guildId!,
+        partnerId: partner?.id,
+        referenceMessageUrl: reference,
+        context: {
+          item: summary,
+          notes,
+          quantity: interaction.options.getInteger('quantity') ?? undefined,
+          budgetRobux: interaction.options.getInteger('budget') ?? undefined,
+        },
+      } satisfies CreateGeneralTicketDTO;
+    case 'SELL':
+      return {
+        type: 'SELL',
+        userId: interaction.user.id,
+        guildId: interaction.guildId!,
+        partnerId: partner?.id,
+        referenceMessageUrl: reference,
+        context: {
+          item: summary,
+          notes,
+          quantity: interaction.options.getInteger('quantity') ?? undefined,
+          priceRobux: interaction.options.getInteger('price') ?? undefined,
+          acceptsMiddleman: interaction.options.getBoolean('accepts_middleman') ?? true,
+        },
+      } satisfies CreateGeneralTicketDTO;
+    case 'ROBUX': {
+      const amount = interaction.options.getInteger('amount', true);
+      const paymentMethod = interaction.options.getString('payment_method', true).trim();
+      return {
+        type: 'ROBUX',
+        userId: interaction.user.id,
+        guildId: interaction.guildId!,
+        partnerId: partner?.id,
+        referenceMessageUrl: reference,
+        context: {
+          amount,
+          paymentMethod,
+          notes,
+        },
+      } satisfies CreateGeneralTicketDTO;
+    }
+    case 'NITRO': {
+      const plan = interaction.options.getString('plan')?.toUpperCase() ?? 'BOOST';
+      return {
+        type: 'NITRO',
+        userId: interaction.user.id,
+        guildId: interaction.guildId!,
+        partnerId: partner?.id,
+        referenceMessageUrl: reference,
+        context: {
+          plan: plan === 'CLASSIC' || plan === 'GIFT' ? (plan as 'CLASSIC' | 'GIFT' | 'BOOST') : 'BOOST',
+          months: interaction.options.getInteger('months') ?? undefined,
+          notes,
+        },
+      } satisfies CreateGeneralTicketDTO;
+    }
+    case 'DECOR':
+      return {
+        type: 'DECOR',
+        userId: interaction.user.id,
+        guildId: interaction.guildId!,
+        partnerId: partner?.id,
+        referenceMessageUrl: reference,
+        context: {
+          asset: summary,
+          theme: interaction.options.getString('theme')?.trim(),
+          notes,
+        },
+      } satisfies CreateGeneralTicketDTO;
+    default:
+      throw new UnauthorizedActionError('tickets:open:unsupported-type');
+  }
+};
+
+const handleOpen = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const guild = ensureGuildInteraction(interaction);
+  await interaction.deferReply({ ephemeral: true });
+
+  const dto = buildOpenDto(interaction);
+  const { ticket, channel } = await openUseCase.execute(dto, guild);
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.success({
+        title: 'Ticket creado',
+        description: `Se creó el ticket **#${ticket.id}** en ${channel}. El personal revisará tu solicitud pronto.`,
+      }),
+    ],
+    components: [TicketShortcutSelect.build()],
+  });
+};
+
+const handleClose = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  ensureGuildInteraction(interaction);
+  const ticketId = interaction.options.getInteger('ticket_id', true);
+  const reason = interaction.options.getString('reason') ?? undefined;
+  const allowOverride = interaction.options.getBoolean('staff_override') ?? false;
+
+  if (allowOverride) {
+    const permissions = interaction.memberPermissions;
+    if (
+      !permissions?.has(PermissionFlagsBits.ManageGuild) &&
+      !permissions?.has(PermissionFlagsBits.ModerateMembers)
+    ) {
+      throw new UnauthorizedActionError('tickets:close:override-permission');
+    }
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const dto: CloseGeneralTicketDTO = {
+    ticketId,
+    executorId: interaction.user.id,
+    reason,
+    allowStaffOverride: allowOverride,
+  };
+
+  await closeUseCase.execute(dto);
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.success({
+        title: 'Ticket cerrado',
+        description: `El ticket **#${ticketId}** se cerró correctamente.`,
+      }),
+    ],
+  });
+};
+
+const handleList = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  ensureGuildInteraction(interaction);
+  await interaction.deferReply({ ephemeral: true });
+
+  const dto: ListUserTicketsDTO = {
+    userId: interaction.options.getUser('user')?.id ?? interaction.user.id,
+    guildId: interaction.guildId!,
+    includeClosed: interaction.options.getBoolean('include_closed') ?? false,
+    limit: interaction.options.getInteger('limit') ?? undefined,
+  };
+
+  const tickets = await listUseCase.execute(dto);
+
+  if (tickets.length === 0) {
+    await interaction.editReply({
+      embeds: [
+        embedFactory.info({
+          title: 'Sin tickets encontrados',
+          description:
+            dto.userId === interaction.user.id
+              ? 'No tienes tickets abiertos en este momento.'
+              : 'El usuario seleccionado no tiene tickets en el historial reciente.',
+        }),
+      ],
+      components: [TicketShortcutSelect.build()],
+    });
+    return;
+  }
+
+  const fields = tickets.map((ticket) => ({
+    name: `#${ticket.id} · ${ticket.type}`,
+    value:
+      `Canal: <#${ticket.channelId.toString()}>\nEstado: ${ticket.status}\nCreado: <t:${Math.floor(
+        ticket.createdAt.getTime() / 1_000,
+      )}:R>`,
+  }));
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.info({
+        title: 'Tickets del usuario',
+        description: 'Listado de tickets generales asociados al usuario indicado.',
+        fields,
+      }),
+    ],
+    components: [TicketShortcutSelect.build()],
+  });
+};
+
+export const ticketCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName('ticket')
+    .setDescription('Gestiona los tickets generales del servidor')
+    .addSubcommand((sub) =>
+      sub
+        .setName('open')
+        .setDescription('Abrir un nuevo ticket general')
+        .addStringOption((option) =>
+          option
+            .setName('type')
+            .setDescription('Tipo de ticket a crear')
+            .setRequired(true)
+            .addChoices(...TYPES),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('summary')
+            .setDescription('Artículo, servicio o asset principal')
+            .setRequired(true),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('notes')
+            .setDescription('Contexto detallado de tu solicitud (mínimo 20 caracteres)')
+            .setRequired(true),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('quantity')
+            .setDescription('Cantidad estimada (para compra/venta)')
+            .setMinValue(1),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('budget')
+            .setDescription('Presupuesto máximo en Robux (tickets de compra)')
+            .setMinValue(1),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('price')
+            .setDescription('Precio solicitado en Robux (tickets de venta)')
+            .setMinValue(1),
+        )
+        .addBooleanOption((option) =>
+          option
+            .setName('accepts_middleman')
+            .setDescription('Indica si aceptas middleman en el ticket de venta'),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('amount')
+            .setDescription('Cantidad de Robux (tickets de Robux)')
+            .setMinValue(1),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('payment_method')
+            .setDescription('Método de pago para el ticket de Robux'),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('plan')
+            .setDescription('Plan de Nitro (tickets de Nitro)')
+            .addChoices(
+              { name: 'Boost', value: 'BOOST' },
+              { name: 'Classic', value: 'CLASSIC' },
+              { name: 'Regalo', value: 'GIFT' },
+            ),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('months')
+            .setDescription('Duración en meses para el ticket de Nitro')
+            .setMinValue(1),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('theme')
+            .setDescription('Tema o estilo solicitado (tickets de decor)'),
+        )
+        .addUserOption((option) =>
+          option
+            .setName('partner')
+            .setDescription('Usuario contraparte involucrado (opcional)'),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('reference')
+            .setDescription('URL del mensaje de referencia con más detalles'),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('close')
+        .setDescription('Cerrar un ticket general existente')
+        .addIntegerOption((option) =>
+          option
+            .setName('ticket_id')
+            .setDescription('Identificador numérico del ticket')
+            .setRequired(true),
+        )
+        .addBooleanOption((option) =>
+          option
+            .setName('staff_override')
+            .setDescription('Permite cerrar incluso si no participaste en el ticket'),
+        )
+        .addStringOption((option) =>
+          option.setName('reason').setDescription('Motivo del cierre (opcional)'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('list')
+        .setDescription('Listar tickets generales de un usuario')
+        .addUserOption((option) =>
+          option
+            .setName('user')
+            .setDescription('Usuario a consultar (por defecto tú)'),
+        )
+        .addBooleanOption((option) =>
+          option
+            .setName('include_closed')
+            .setDescription('Incluir tickets cerrados en el resultado'),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('limit')
+            .setDescription('Número máximo de tickets a mostrar (1-25)')
+            .setMinValue(1)
+            .setMaxValue(25),
+        ),
+    ),
+  category: 'Tickets',
+  examples: [
+    '/ticket open type:buy summary:"Limited" notes:"Busco limiteds a buen precio"',
+    '/ticket close ticket_id:42',
+    '/ticket list include_closed:true',
+  ],
+  async execute(interaction) {
+    const subcommand = interaction.options.getSubcommand();
+
+    switch (subcommand) {
+      case 'open':
+        await handleOpen(interaction);
+        break;
+      case 'close':
+        await handleClose(interaction);
+        break;
+      case 'list':
+        await handleList(interaction);
+        break;
+      default:
+        await interaction.reply({
+          embeds: [
+            embedFactory.warning({
+              title: 'Subcomando no disponible',
+              description: 'La acción solicitada no está implementada.',
+            }),
+          ],
+          ephemeral: true,
+        });
+    }
+  },
+};

--- a/src/presentation/components/registry.ts
+++ b/src/presentation/components/registry.ts
@@ -2,14 +2,20 @@
 // RUTA: src/presentation/components/registry.ts
 // ============================================================================
 
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import type {
+  ButtonInteraction,
+  ModalSubmitInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
 import { Collection } from 'discord.js';
 
 type ButtonHandler = (interaction: ButtonInteraction) => Promise<void>;
 type ModalHandler = (interaction: ModalSubmitInteraction) => Promise<void>;
+type SelectHandler = (interaction: StringSelectMenuInteraction) => Promise<void>;
 
 export const buttonHandlers = new Collection<string, ButtonHandler>();
 export const modalHandlers = new Collection<string, ModalHandler>();
+export const selectHandlers = new Collection<string, SelectHandler>();
 
 export const registerButtonHandler = (customId: string, handler: ButtonHandler): void => {
   if (buttonHandlers.has(customId)) {
@@ -23,4 +29,11 @@ export const registerModalHandler = (customId: string, handler: ModalHandler): v
     throw new Error(`El modal con customId ${customId} ya está registrado.`);
   }
   modalHandlers.set(customId, handler);
+};
+
+export const registerSelectHandler = (customId: string, handler: SelectHandler): void => {
+  if (selectHandlers.has(customId)) {
+    throw new Error(`El select con customId ${customId} ya está registrado.`);
+  }
+  selectHandlers.set(customId, handler);
 };

--- a/src/presentation/components/selects/TicketShortcutSelect.ts
+++ b/src/presentation/components/selects/TicketShortcutSelect.ts
@@ -1,0 +1,60 @@
+// =============================================================================
+// RUTA: src/presentation/components/selects/TicketShortcutSelect.ts
+// =============================================================================
+
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+
+import { GeneralTicketTypeSchema } from '@/application/dto/ticket.dto';
+import { registerSelectHandler } from '@/presentation/components/registry';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+
+const CUSTOM_ID = 'ticket-shortcuts';
+
+const OPTIONS = [
+  { label: 'Comprar artículo', value: 'BUY', description: 'Publica una compra de ítems o servicios.' },
+  { label: 'Vender artículo', value: 'SELL', description: 'Ofrece ítems o servicios a la venta.' },
+  { label: 'Comprar/Vender Robux', value: 'ROBUX', description: 'Negocia Robux con métodos verificados.' },
+  { label: 'Nitro', value: 'NITRO', description: 'Solicita o vende suscripciones de Discord Nitro.' },
+  { label: 'Decor / Builds', value: 'DECOR', description: 'Encarga decoraciones, builds o diseños.' },
+] as const;
+
+export const TicketShortcutSelect = {
+  build(): ActionRowBuilder<StringSelectMenuBuilder> {
+    const select = new StringSelectMenuBuilder()
+      .setCustomId(CUSTOM_ID)
+      .setPlaceholder('Selecciona el tipo de ticket que necesitas')
+      .addOptions(OPTIONS.map((option) => ({
+        label: option.label,
+        value: option.value,
+        description: option.description,
+      })));
+
+    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  },
+
+  async handle(interaction: StringSelectMenuInteraction): Promise<void> {
+    const [rawType] = interaction.values;
+    const type = GeneralTicketTypeSchema.parse(rawType);
+    const command = `/ticket open type:${type.toLowerCase()}`;
+
+    await interaction.reply({
+      embeds: [
+        embedFactory.info({
+          title: 'Atajo de ticket',
+          description:
+            `Utiliza el comando ${command} para iniciar la solicitud. ` +
+            'Añade los detalles del artículo, presupuesto y contraparte en las opciones solicitadas.',
+        }),
+      ],
+      ephemeral: true,
+    });
+  },
+};
+
+registerSelectHandler(CUSTOM_ID, async (interaction) => {
+  await TicketShortcutSelect.handle(interaction);
+});

--- a/src/presentation/events/interactionCreate.ts
+++ b/src/presentation/events/interactionCreate.ts
@@ -7,11 +7,16 @@ import type {
   ChatInputCommandInteraction,
   Interaction,
   ModalSubmitInteraction,
+  StringSelectMenuInteraction,
 } from 'discord.js';
 import { Events } from 'discord.js';
 
 import { commandRegistry } from '@/presentation/commands';
-import { buttonHandlers, modalHandlers } from '@/presentation/components/registry';
+import {
+  buttonHandlers,
+  modalHandlers,
+  selectHandlers,
+} from '@/presentation/components/registry';
 import { embedFactory } from '@/presentation/embeds/EmbedFactory';
 import type { EventDescriptor } from '@/presentation/events/types';
 import { mapErrorToDiscordResponse } from '@/shared/errors/discord-error-mapper';
@@ -78,6 +83,27 @@ const handleModal = async (interaction: ModalSubmitInteraction): Promise<void> =
   await handler(interaction);
 };
 
+const handleSelect = async (interaction: StringSelectMenuInteraction): Promise<void> => {
+  const handler = selectHandlers.get(interaction.customId);
+
+  if (!handler) {
+    logger.warn({ customId: interaction.customId }, 'No existe handler registrado para el menú select.');
+    await interaction.reply({
+      embeds: [
+        embedFactory.warning({
+          title: 'Acción no disponible',
+          description:
+            'Este menú ya no está activo. Ejecuta nuevamente el comando original para obtener una versión actualizada.',
+        }),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await handler(interaction);
+};
+
 export const interactionCreateEvent: EventDescriptor<typeof Events.InteractionCreate> = {
   name: Events.InteractionCreate,
   once: false,
@@ -95,6 +121,11 @@ export const interactionCreateEvent: EventDescriptor<typeof Events.InteractionCr
 
       if (interaction.isModalSubmit()) {
         await handleModal(interaction);
+        return;
+      }
+
+      if (interaction.isStringSelectMenu()) {
+        await handleSelect(interaction);
         return;
       }
     } catch (error) {

--- a/src/shared/errors/domain.errors.ts
+++ b/src/shared/errors/domain.errors.ts
@@ -170,6 +170,39 @@ export class DuplicateReviewError extends DedosError {
   }
 }
 
+export class TicketPolicyNotFoundError extends DedosError {
+  public constructor(type: string) {
+    super({
+      code: 'TICKET_POLICY_NOT_FOUND',
+      message: 'No existe una política configurada para este tipo de ticket.',
+      metadata: { type },
+      exposeMessage: false,
+    });
+  }
+}
+
+export class TicketCooldownActiveError extends DedosError {
+  public constructor(type: string, remainingSeconds: number) {
+    super({
+      code: 'TICKET_COOLDOWN_ACTIVE',
+      message: `Debes esperar ${remainingSeconds} segundos antes de abrir otro ticket de este tipo.`,
+      metadata: { type, remainingSeconds },
+      exposeMessage: true,
+    });
+  }
+}
+
+export class TicketParticipantNotFoundError extends DedosError {
+  public constructor(ticketId: number, userId: string) {
+    super({
+      code: 'TICKET_PARTICIPANT_NOT_FOUND',
+      message: 'No estás registrado como participante de este ticket.',
+      metadata: { ticketId, userId },
+      exposeMessage: true,
+    });
+  }
+}
+
 export class DiscordEntityCreationError extends DedosError {
   public constructor(entity: string, cause?: unknown) {
     super({

--- a/tests/unit/application/usecases/tickets/CloseGeneralTicketUseCase.test.ts
+++ b/tests/unit/application/usecases/tickets/CloseGeneralTicketUseCase.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CloseGeneralTicketUseCase } from '@/application/usecases/tickets/CloseGeneralTicketUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import type { FindTicketsByOwnerOptions, ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import {
+  TicketParticipantNotFoundError,
+  TicketNotFoundError,
+} from '@/shared/errors/domain.errors';
+import type { Logger } from '@/shared/logger/pino';
+
+class MockTicketRepository implements ITicketRepository {
+  public ticket: Ticket | null = new Ticket(
+    1,
+    111111111111111111n,
+    222222222222222222n,
+    333333333333333333n,
+    TicketType.BUY,
+    TicketStatus.OPEN,
+    new Date(),
+  );
+  public update = vi.fn(async (ticket: Ticket) => {
+    this.ticket = ticket;
+  });
+
+  public withTransaction(): ITicketRepository {
+    return this;
+  }
+
+  public async create(): Promise<Ticket> {
+    throw new Error('Not implemented');
+  }
+
+  public async findById(id: number): Promise<Ticket | null> {
+    return this.ticket && this.ticket.id === id ? this.ticket : null;
+  }
+
+  public async findByChannelId(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findOpenByOwner(): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async findByOwner(_ownerId: bigint, _options?: FindTicketsByOwnerOptions): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async delete(): Promise<void> {}
+
+  public async countOpenByOwner(_ownerId: bigint): Promise<number> {
+    return 0;
+  }
+
+  public async countOpenByOwnerAndType(_ownerId: bigint, _type: TicketType): Promise<number> {
+    return 0;
+  }
+
+  public async isParticipant(): Promise<boolean> {
+    return true;
+  }
+}
+
+class MockParticipantRepository implements ITicketParticipantRepository {
+  public withTransaction(): ITicketParticipantRepository {
+    return this;
+  }
+
+  public async addMany(): Promise<void> {}
+
+  public async remove(): Promise<void> {}
+
+  public async list(): Promise<readonly never[]> {
+    return [];
+  }
+
+  public isParticipant = vi.fn<[], Promise<boolean>>().mockResolvedValue(true);
+}
+
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+  level: 'silent',
+} as unknown as Logger;
+
+describe('CloseGeneralTicketUseCase', () => {
+  it('cierra el ticket cuando el usuario participa', async () => {
+    const repo = new MockTicketRepository();
+    const participants = new MockParticipantRepository();
+    const useCase = new CloseGeneralTicketUseCase(repo, participants, logger);
+
+    await useCase.execute({ ticketId: 1, executorId: '333333333333333333', reason: 'Listo' });
+
+    expect(repo.ticket?.isClosed()).toBe(true);
+    expect(repo.update).toHaveBeenCalled();
+  });
+
+  it('lanza error cuando el ticket no existe', async () => {
+    const repo = new MockTicketRepository();
+    repo.ticket = null;
+    const participants = new MockParticipantRepository();
+    const useCase = new CloseGeneralTicketUseCase(repo, participants, logger);
+
+    await expect(useCase.execute({ ticketId: 999, executorId: '111111111111111111' })).rejects.toBeInstanceOf(
+      TicketNotFoundError,
+    );
+  });
+
+  it('requiere participación cuando no hay override', async () => {
+    const repo = new MockTicketRepository();
+    const participants = new MockParticipantRepository();
+    participants.isParticipant.mockResolvedValue(false);
+    const useCase = new CloseGeneralTicketUseCase(repo, participants, logger);
+
+    await expect(useCase.execute({ ticketId: 1, executorId: '444444444444444444' })).rejects.toBeInstanceOf(
+      TicketParticipantNotFoundError,
+    );
+  });
+
+  it('cierra el ticket con override aunque no participe', async () => {
+    const repo = new MockTicketRepository();
+    const participants = new MockParticipantRepository();
+    participants.isParticipant.mockResolvedValue(false);
+    const useCase = new CloseGeneralTicketUseCase(repo, participants, logger);
+
+    await useCase.execute({ ticketId: 1, executorId: '444444444444444444', allowStaffOverride: true });
+
+    expect(repo.ticket?.isClosed()).toBe(true);
+  });
+});

--- a/tests/unit/application/usecases/tickets/ListUserTicketsUseCase.test.ts
+++ b/tests/unit/application/usecases/tickets/ListUserTicketsUseCase.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { ListUserTicketsUseCase } from '@/application/usecases/tickets/ListUserTicketsUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type { CreateTicketData, FindTicketsByOwnerOptions, ITicketRepository } from '@/domain/repositories/ITicketRepository';
+
+class MockTicketRepository implements ITicketRepository {
+  public tickets: Ticket[] = [
+    new Ticket(
+      1,
+      111111111111111111n,
+      222222222222222222n,
+      333333333333333333n,
+      TicketType.BUY,
+      TicketStatus.OPEN,
+      new Date(),
+    ),
+    new Ticket(
+      2,
+      111111111111111111n,
+      333333333333333333n,
+      333333333333333333n,
+      TicketType.MM,
+      TicketStatus.CLAIMED,
+      new Date(),
+    ),
+  ];
+  public options: FindTicketsByOwnerOptions | undefined;
+
+  public withTransaction(): ITicketRepository {
+    return this;
+  }
+
+  public async create(): Promise<Ticket> {
+    throw new Error('Not implemented');
+  }
+
+  public async findById(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findByChannelId(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findOpenByOwner(): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async findByOwner(_ownerId: bigint, options?: FindTicketsByOwnerOptions): Promise<readonly Ticket[]> {
+    this.options = options;
+    return this.tickets;
+  }
+
+  public async update(): Promise<void> {}
+
+  public async delete(): Promise<void> {}
+
+  public async countOpenByOwner(_ownerId: bigint): Promise<number> {
+    return 0;
+  }
+
+  public async countOpenByOwnerAndType(_ownerId: bigint, _type: TicketType): Promise<number> {
+    return 0;
+  }
+
+  public async isParticipant(): Promise<boolean> {
+    return false;
+  }
+}
+
+describe('ListUserTicketsUseCase', () => {
+  it('filtra tickets no middleman y aplica estados abiertos por defecto', async () => {
+    const repo = new MockTicketRepository();
+    const useCase = new ListUserTicketsUseCase(repo);
+
+    const tickets = await useCase.execute({
+      userId: '333333333333333333',
+      guildId: '111111111111111111',
+      includeClosed: false,
+      limit: 5,
+    });
+
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0].type).toBe(TicketType.BUY);
+    expect(repo.options?.statuses).toEqual([TicketStatus.OPEN, TicketStatus.CONFIRMED, TicketStatus.CLAIMED]);
+    expect(repo.options?.limit).toBe(5);
+  });
+
+  it('cuando incluye cerrados no filtra estados', async () => {
+    const repo = new MockTicketRepository();
+    const useCase = new ListUserTicketsUseCase(repo);
+
+    await useCase.execute({
+      userId: '333333333333333333',
+      guildId: '111111111111111111',
+      includeClosed: true,
+    });
+
+    expect(repo.options?.statuses).toBeUndefined();
+  });
+});

--- a/tests/unit/application/usecases/tickets/OpenGeneralTicketUseCase.test.ts
+++ b/tests/unit/application/usecases/tickets/OpenGeneralTicketUseCase.test.ts
@@ -1,0 +1,247 @@
+import type { PrismaClient } from '@prisma/client';
+import type { Guild, TextChannel } from 'discord.js';
+import type { Logger } from 'pino';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type CreateGeneralTicketDTO } from '@/application/dto/ticket.dto';
+import { OpenGeneralTicketUseCase } from '@/application/usecases/tickets/OpenGeneralTicketUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type {
+  ITicketParticipantRepository,
+  TicketParticipantRecord,
+} from '@/domain/repositories/ITicketParticipantRepository';
+import type {
+  CreateTicketData,
+  FindTicketsByOwnerOptions,
+  ITicketRepository,
+  TicketParticipantInput,
+} from '@/domain/repositories/ITicketRepository';
+import type {
+  ITicketTypePolicyRepository,
+  TicketTypeCooldown,
+  TicketTypePolicy,
+} from '@/domain/repositories/ITicketTypePolicyRepository';
+import { TicketCooldownActiveError, TooManyOpenTicketsError } from '@/shared/errors/domain.errors';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+
+class MockPrismaClient {
+  public $transaction = vi.fn(async (callback: (tx: unknown) => Promise<Ticket>) => callback({}));
+}
+
+class MockTicketRepository implements ITicketRepository {
+  public createdTickets: CreateTicketData[] = [];
+  public openTickets = 0;
+
+  public withTransaction(): ITicketRepository {
+    return this;
+  }
+
+  public async create(data: CreateTicketData): Promise<Ticket> {
+    this.createdTickets.push(data);
+    return new Ticket(1, data.guildId, data.channelId, data.ownerId, data.type, TicketStatus.OPEN, new Date());
+  }
+
+  public async findById(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findByChannelId(): Promise<Ticket | null> {
+    return null;
+  }
+
+  public async findOpenByOwner(): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async findByOwner(_ownerId: bigint, _options?: FindTicketsByOwnerOptions): Promise<readonly Ticket[]> {
+    return [];
+  }
+
+  public async update(): Promise<void> {}
+
+  public async delete(): Promise<void> {}
+
+  public async countOpenByOwner(_ownerId: bigint): Promise<number> {
+    return this.openTickets;
+  }
+
+  public async countOpenByOwnerAndType(_ownerId: bigint, _type: TicketType): Promise<number> {
+    return this.openTickets;
+  }
+
+  public async isParticipant(): Promise<boolean> {
+    return false;
+  }
+}
+
+class MockParticipantRepository implements ITicketParticipantRepository {
+  public added: ReadonlyArray<TicketParticipantInput> = [];
+
+  public withTransaction(): ITicketParticipantRepository {
+    return this;
+  }
+
+  public async addMany(_ticketId: number, participants: ReadonlyArray<TicketParticipantInput>): Promise<void> {
+    this.added = participants;
+  }
+
+  public async remove(): Promise<void> {}
+
+  public async list(): Promise<readonly TicketParticipantRecord[]> {
+    return this.added.map((participant) => ({
+      ticketId: 1,
+      userId: participant.userId,
+      role: participant.role ?? null,
+      joinedAt: participant.joinedAt ?? new Date(),
+    }));
+  }
+
+  public async isParticipant(): Promise<boolean> {
+    return true;
+  }
+}
+
+class MockPolicyRepository implements ITicketTypePolicyRepository {
+  public policy: TicketTypePolicy = {
+    type: TicketType.BUY,
+    maxOpenPerUser: 2,
+    cooldownSeconds: 60,
+    requiresStaffApproval: false,
+  };
+  public cooldown: TicketTypeCooldown | null = null;
+
+  public withTransaction(): ITicketTypePolicyRepository {
+    return this;
+  }
+
+  public async getPolicy(): Promise<TicketTypePolicy | null> {
+    return this.policy;
+  }
+
+  public async getAllPolicies(): Promise<readonly TicketTypePolicy[]> {
+    return [this.policy];
+  }
+
+  public async getCooldown(): Promise<TicketTypeCooldown | null> {
+    return this.cooldown;
+  }
+
+  public async upsertCooldown(): Promise<void> {}
+}
+
+const createLogger = (): Logger =>
+  ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: 'silent',
+  } as unknown as Logger);
+
+const createGuild = (channel: TextChannel): Guild =>
+  ({
+    id: '123',
+    members: { me: { id: 'bot' } },
+    roles: { everyone: { id: 'everyone' } },
+    channels: { create: vi.fn().mockResolvedValue(channel) },
+  } as unknown as Guild);
+
+describe('OpenGeneralTicketUseCase', () => {
+  let prisma: MockPrismaClient;
+  let repo: MockTicketRepository;
+  let participantRepo: MockParticipantRepository;
+  let policyRepo: MockPolicyRepository;
+  let logger: Logger;
+  let channel: TextChannel & { send: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+  let guild: Guild;
+  let useCase: OpenGeneralTicketUseCase;
+
+  beforeEach(() => {
+    prisma = new MockPrismaClient();
+    repo = new MockTicketRepository();
+    participantRepo = new MockParticipantRepository();
+    policyRepo = new MockPolicyRepository();
+    logger = createLogger();
+    channel = {
+      id: '999',
+      send: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      permissionOverwrites: { edit: vi.fn().mockResolvedValue(undefined) },
+    } as unknown as TextChannel & { send: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> };
+    guild = createGuild(channel);
+    useCase = new OpenGeneralTicketUseCase(
+      prisma as unknown as PrismaClient,
+      repo,
+      participantRepo,
+      policyRepo,
+      logger,
+      embedFactory,
+    );
+  });
+
+  it('crea ticket y canal con éxito', async () => {
+    const dto: CreateGeneralTicketDTO = {
+      type: 'BUY',
+      userId: '123456789012345678',
+      guildId: '987654321098765432',
+      context: {
+        item: 'Limited UGC',
+        notes: 'Busco el item a precio competitivo',
+      },
+    };
+
+    const result = await useCase.execute(dto, guild);
+
+    expect(result.ticket.id).toBe(1);
+    expect(result.channel).toBe(channel);
+    expect(repo.createdTickets).toHaveLength(1);
+    expect(channel.send).toHaveBeenCalled();
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('lanza error cuando el usuario alcanza el límite', async () => {
+    repo.openTickets = 2;
+
+    await expect(
+      useCase.execute(
+        {
+          type: 'BUY',
+          userId: '123456789012345678',
+          guildId: '987654321098765432',
+          context: {
+            item: 'Limited',
+            notes: 'Necesito comprar ahora mismo',
+          },
+        },
+        guild,
+      ),
+    ).rejects.toBeInstanceOf(TooManyOpenTicketsError);
+  });
+
+  it('lanza error si existe un cooldown activo', async () => {
+    policyRepo.cooldown = {
+      type: TicketType.BUY,
+      userId: 123456789012345678n,
+      lastOpenedAt: new Date(),
+    };
+
+    await expect(
+      useCase.execute(
+        {
+          type: 'BUY',
+          userId: '123456789012345678',
+          guildId: '987654321098765432',
+          context: {
+            item: 'Limited',
+            notes: 'Intento abrir otro ticket demasiado pronto',
+          },
+        },
+        guild,
+      ),
+    ).rejects.toBeInstanceOf(TicketCooldownActiveError);
+  });
+});


### PR DESCRIPTION
## Summary
- add general ticket DTO validation and domain policies with cooldown persistence
- implement Prisma repositories and use cases for opening, closing, and listing general tickets
- expose /ticket command with shortcut select component and document staff guidance

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ddde39bd5483269d183d1e50ea0040