### PR TITLE
feat: add general ticket workflow

### DIFF
--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -1,0 +1,49 @@
+# Tickets generales
+
+El sistema de tickets generales complementa el flujo de middleman permitiendo a los usuarios abrir canales privados para compras, ventas y solicitudes específicas. Este documento resume las reglas de creación, los límites y el proceso recomendado para desplegar los cambios.
+
+## Tipos disponibles
+
+| Tipo (`TicketType`) | Descripción breve | Límite de tickets abiertos | Cooldown aproximado |
+| --- | --- | --- | --- |
+| `BUY` | Solicitudes de compra de ítems o servicios. | 3 tickets simultáneos | 30 minutos entre aperturas |
+| `SELL` | Publicaciones de venta y ofertas directas. | 3 tickets simultáneos | 30 minutos entre aperturas |
+| `ROBUX` | Intercambios o compra/venta de Robux. | 1 ticket simultáneo | 120 minutos entre aperturas |
+| `NITRO` | Gestión de regalos o compras de Nitro. | 1 ticket simultáneo | 120 minutos entre aperturas |
+| `DECOR` | Canales de diseño, decoración o gráficos. | 2 tickets simultáneos | 60 minutos entre aperturas |
+
+> ℹ️ Los límites se validan antes de crear el canal. Si se supera el límite o el usuario se encuentra en cooldown, el bot responde con un error explícito (`TooManyOpenTicketsError` o `TicketCooldownError`).
+
+## Flujo resumido
+
+1. El usuario ejecuta `/ticket open` indicando el tipo y el contexto.
+2. `OpenGeneralTicketUseCase` verifica políticas (límite y cooldown) mediante `PrismaTicketPolicyRepository`.
+3. Si pasa la validación, se crea un canal privado y se registra al propietario (y partner opcional) en `PrismaTicketParticipantRepository`.
+4. El bot envía un embed inicial en el canal con el resumen de la solicitud.
+5. El subcomando `/ticket close` o el selector rápido marcan el ticket como cerrado a través de `CloseGeneralTicketUseCase`.
+6. `/ticket list` consulta los tickets abiertos y recientes para el usuario, facilitando auditorías rápidas.
+
+Los selectores rápidos (`buildTicketQuickOpenRow`) permiten crear tickets preconfigurados sin escribir el comando completo. Cada opción invoca el caso de uso de apertura con un contexto genérico que luego puede ampliarse en el canal.
+
+## Despliegue
+
+1. Ejecutar las pruebas locales:
+   ```bash
+   npm run lint
+   npm run test
+   ```
+2. Generar el cliente de Prisma por si se actualizó el schema:
+   ```bash
+   npm run db:generate
+   ```
+3. Construir el proyecto y actualizar los artefactos de distribución:
+   ```bash
+   npm run build
+   ```
+4. Desplegar el bot (ej. a Docker/PM2) y verificar logs de creación/cierre de tickets.
+5. Registrar los comandos con el nuevo subcomando `/ticket`:
+   ```bash
+   npm run deploy:commands
+   ```
+
+Mantén el archivo `.env` actualizado con el `DISCORD_GUILD_ID` si necesitas desplegar los comandos solo en un servidor durante QA.

--- a/src/application/dto/ticket-general.dto.ts
+++ b/src/application/dto/ticket-general.dto.ts
@@ -1,0 +1,41 @@
+// =============================================================================
+// RUTA: src/application/dto/ticket-general.dto.ts
+// =============================================================================
+
+import { z } from 'zod';
+
+import { TicketType } from '@/domain/entities/types';
+
+const SnowflakeSchema = z.string().regex(/^[0-9]{17,20}$/u, 'Invalid Discord snowflake');
+const ContextSchema = z.string().min(10, 'Context must contain at least 10 characters').max(1000, 'Context must not exceed 1000 characters');
+
+const buildGeneralTicketSchema = <TType extends TicketType>(type: TType) =>
+  z.object({
+    userId: SnowflakeSchema,
+    guildId: SnowflakeSchema,
+    type: z.literal(type),
+    context: ContextSchema,
+    partnerTag: z.string().regex(/^<@\d{17,20}>$/u, 'Invalid Discord mention').optional(),
+  });
+
+export const CreateBuyTicketSchema = buildGeneralTicketSchema(TicketType.BUY);
+export const CreateSellTicketSchema = buildGeneralTicketSchema(TicketType.SELL);
+export const CreateRobuxTicketSchema = buildGeneralTicketSchema(TicketType.ROBUX);
+export const CreateNitroTicketSchema = buildGeneralTicketSchema(TicketType.NITRO);
+export const CreateDecorTicketSchema = buildGeneralTicketSchema(TicketType.DECOR);
+
+export type CreateBuyTicketDTO = z.infer<typeof CreateBuyTicketSchema>;
+export type CreateSellTicketDTO = z.infer<typeof CreateSellTicketSchema>;
+export type CreateRobuxTicketDTO = z.infer<typeof CreateRobuxTicketSchema>;
+export type CreateNitroTicketDTO = z.infer<typeof CreateNitroTicketSchema>;
+export type CreateDecorTicketDTO = z.infer<typeof CreateDecorTicketSchema>;
+
+export const CreateGeneralTicketSchema = z.discriminatedUnion('type', [
+  CreateBuyTicketSchema,
+  CreateSellTicketSchema,
+  CreateRobuxTicketSchema,
+  CreateNitroTicketSchema,
+  CreateDecorTicketSchema,
+]);
+
+export type CreateGeneralTicketDTO = z.infer<typeof CreateGeneralTicketSchema>;

--- a/src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
+++ b/src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
@@ -1,0 +1,61 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/CloseGeneralTicketUseCase.ts
+// =============================================================================
+
+import type { TextChannel } from 'discord.js';
+import type { Logger } from 'pino';
+
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import { embedFactory, type EmbedFactory } from '@/presentation/embeds/EmbedFactory';
+import {
+  TicketClosedError,
+  TicketNotFoundError,
+  UnauthorizedActionError,
+} from '@/shared/errors/domain.errors';
+import type { PrismaClient } from '@prisma/client';
+
+export class CloseGeneralTicketUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly participantRepo: ITicketParticipantRepository,
+    private readonly prisma: PrismaClient,
+    private readonly logger: Logger,
+    private readonly embeds: EmbedFactory = embedFactory,
+  ) {}
+
+  public async execute(ticketId: number, actorId: string | bigint, channel: TextChannel): Promise<void> {
+    const requesterId = typeof actorId === 'bigint' ? actorId : BigInt(actorId);
+
+    const ticket = await this.ticketRepo.findById(ticketId);
+    if (!ticket) {
+      throw new TicketNotFoundError(String(ticketId));
+    }
+
+    if (ticket.isClosed()) {
+      throw new TicketClosedError(ticketId);
+    }
+
+    const isOwner = ticket.isOwnedBy(requesterId);
+    const isParticipant = await this.participantRepo.isParticipant(ticketId, requesterId);
+
+    if (!isOwner && !isParticipant) {
+      throw new UnauthorizedActionError('ticket:close');
+    }
+
+    ticket.close();
+
+    await this.prisma.$transaction(async (tx) => {
+      await this.ticketRepo.withTransaction(tx).update(ticket);
+    });
+
+    const embed = this.embeds.success({
+      title: `Ticket #${ticket.id} cerrado`,
+      description: 'Se marcó el ticket como cerrado. Gracias por usar el sistema de tickets.',
+    });
+
+    await channel.send({ embeds: [embed] });
+
+    this.logger.info({ ticketId, actorId: requesterId.toString(), channelId: channel.id }, 'General ticket closed.');
+  }
+}

--- a/src/application/usecases/tickets/ListUserTicketsUseCase.ts
+++ b/src/application/usecases/tickets/ListUserTicketsUseCase.ts
@@ -1,0 +1,52 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/ListUserTicketsUseCase.ts
+// =============================================================================
+
+import type { Logger } from 'pino';
+
+import type { Ticket } from '@/domain/entities/Ticket';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { TicketStatus, TicketType } from '@/domain/entities/types';
+
+export interface TicketSummary {
+  readonly id: number;
+  readonly type: TicketType;
+  readonly status: TicketStatus;
+  readonly createdAt: Date;
+  readonly closedAt?: Date;
+}
+
+export interface ListUserTicketsResult {
+  readonly open: readonly TicketSummary[];
+  readonly recent: readonly TicketSummary[];
+}
+
+export class ListUserTicketsUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  public async execute(userId: string | bigint, limit = 10): Promise<ListUserTicketsResult> {
+    const ownerId = typeof userId === 'bigint' ? userId : BigInt(userId);
+    this.logger.debug({ ownerId: ownerId.toString(), limit }, 'Listing tickets for user.');
+
+    const [openTickets, recentTickets] = await Promise.all([
+      this.ticketRepo.findOpenByOwner(ownerId),
+      this.ticketRepo.findRecentByOwner(ownerId, limit),
+    ]);
+
+    const mapTicket = (ticket: Ticket): TicketSummary => ({
+      id: ticket.id,
+      type: ticket.type,
+      status: ticket.status,
+      createdAt: ticket.createdAt,
+      closedAt: ticket.closedAt,
+    });
+
+    return {
+      open: openTickets.map(mapTicket),
+      recent: recentTickets.map(mapTicket),
+    };
+  }
+}

--- a/src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
+++ b/src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
@@ -1,0 +1,164 @@
+// =============================================================================
+// RUTA: src/application/usecases/tickets/OpenGeneralTicketUseCase.ts
+// =============================================================================
+
+import type { Guild, TextChannel } from 'discord.js';
+import { ChannelType, PermissionFlagsBits } from 'discord.js';
+import type { Logger } from 'pino';
+
+import { CreateGeneralTicketSchema, type CreateGeneralTicketDTO } from '@/application/dto/ticket-general.dto';
+import { TicketType } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import type { ITicketPolicyRepository } from '@/domain/repositories/ITicketPolicyRepository';
+import { embedFactory, type EmbedFactory } from '@/presentation/embeds/EmbedFactory';
+import { TicketCooldownError, TooManyOpenTicketsError } from '@/shared/errors/domain.errors';
+import { sanitizeChannelName } from '@/shared/utils/discord.utils';
+import type { PrismaClient } from '@prisma/client';
+
+const GENERAL_POLICIES: Record<Exclude<TicketType, TicketType.MM>, { maxOpen: number; cooldownMinutes: number; label: string }>
+  = {
+    [TicketType.BUY]: { maxOpen: 3, cooldownMinutes: 30, label: 'Compra' },
+    [TicketType.SELL]: { maxOpen: 3, cooldownMinutes: 30, label: 'Venta' },
+    [TicketType.ROBUX]: { maxOpen: 1, cooldownMinutes: 120, label: 'Robux' },
+    [TicketType.NITRO]: { maxOpen: 1, cooldownMinutes: 120, label: 'Nitro' },
+    [TicketType.DECOR]: { maxOpen: 2, cooldownMinutes: 60, label: 'Decoración' },
+  } as const;
+
+const SNOWFLAKE_EXTRACTOR = /\d{17,20}/u;
+
+const extractSnowflake = (value?: string | null): bigint | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const match = value.match(SNOWFLAKE_EXTRACTOR);
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    return BigInt(match[0]);
+  } catch {
+    return undefined;
+  }
+};
+
+export class OpenGeneralTicketUseCase {
+  public constructor(
+    private readonly ticketRepo: ITicketRepository,
+    private readonly policyRepo: ITicketPolicyRepository,
+    private readonly participantRepo: ITicketParticipantRepository,
+    private readonly prisma: PrismaClient,
+    private readonly logger: Logger,
+    private readonly embeds: EmbedFactory = embedFactory,
+  ) {}
+
+  public async execute(
+    dto: CreateGeneralTicketDTO,
+    guild: Guild,
+  ): Promise<{ ticket: Awaited<ReturnType<ITicketRepository['create']>>; channel: TextChannel }> {
+    const payload = CreateGeneralTicketSchema.parse(dto);
+    if (payload.type === TicketType.MM) {
+      throw new Error('General ticket use case does not support middleman tickets.');
+    }
+
+    const ownerId = BigInt(payload.userId);
+    const guildId = BigInt(payload.guildId);
+    const policy = GENERAL_POLICIES[payload.type];
+
+    this.logger.debug({ ownerId: payload.userId, type: payload.type }, 'Evaluating ticket policy snapshot.');
+    const snapshot = await this.policyRepo.getSnapshot(ownerId, payload.type);
+
+    if (snapshot.openCount >= policy.maxOpen) {
+      this.logger.info({ ownerId: payload.userId, type: payload.type }, 'Ticket limit reached for owner.');
+      throw new TooManyOpenTicketsError(policy.maxOpen);
+    }
+
+    if (snapshot.lastOpenedAt) {
+      const cooldownMs = policy.cooldownMinutes * 60 * 1000;
+      const elapsed = Date.now() - snapshot.lastOpenedAt.getTime();
+      if (elapsed < cooldownMs) {
+        const availableAt = new Date(snapshot.lastOpenedAt.getTime() + cooldownMs);
+        this.logger.info({ ownerId: payload.userId, type: payload.type, availableAt }, 'Ticket opening on cooldown.');
+        throw new TicketCooldownError(availableAt);
+      }
+    }
+
+    const botId = guild.members.me?.id;
+
+    if (!botId) {
+      throw new Error('Bot must be present in guild to open ticket.');
+    }
+
+    const channelName = sanitizeChannelName(`${payload.type.toLowerCase()}-${payload.userId}`);
+    this.logger.debug({ channelName, guildId: payload.guildId }, 'Creating general ticket channel.');
+
+    let channel: TextChannel;
+
+    try {
+      channel = await guild.channels.create({
+        name: channelName,
+        type: ChannelType.GuildText,
+        topic: payload.context.slice(0, 1000),
+        permissionOverwrites: [
+          { id: guild.roles.everyone.id, deny: [PermissionFlagsBits.ViewChannel] },
+          { id: payload.userId, allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.ReadMessageHistory] },
+          { id: botId, allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.ManageChannels, PermissionFlagsBits.ReadMessageHistory] },
+        ],
+      });
+    } catch (error) {
+      this.logger.error({ err: error, ownerId: payload.userId }, 'Failed to create general ticket channel.');
+      throw error;
+    }
+
+    const partnerId = extractSnowflake(payload.partnerTag ?? null);
+
+    try {
+      const ticket = await this.prisma.$transaction(async (tx) => {
+        const transactionalTicketRepo = this.ticketRepo.withTransaction(tx);
+        const transactionalParticipantRepo = this.participantRepo.withTransaction(tx);
+
+        const createdTicket = await transactionalTicketRepo.create({
+          guildId,
+          channelId: BigInt(channel.id),
+          ownerId,
+          type: payload.type,
+        });
+
+        await transactionalParticipantRepo.addParticipant({ ticketId: createdTicket.id, userId: ownerId, role: 'OWNER' });
+        if (partnerId) {
+          await transactionalParticipantRepo.addParticipant({ ticketId: createdTicket.id, userId: partnerId, role: 'PARTNER' });
+        }
+
+        return createdTicket;
+      });
+
+      const embed = this.embeds.ticketCreated({
+        ticketId: ticket.id,
+        type: policy.label,
+        ownerTag: `<@${payload.userId}>`,
+        description: payload.context,
+      });
+
+      await channel.send({
+        content: [payload.userId, partnerId ? String(partnerId) : null]
+          .filter(Boolean)
+          .map((id) => `<@${id}>`)
+          .join(' '),
+        embeds: [embed],
+      });
+
+      this.logger.info(
+        { ticketId: ticket.id, ownerId: payload.userId, channelId: channel.id, type: payload.type },
+        'General ticket created successfully.',
+      );
+
+      return { ticket, channel };
+    } catch (error) {
+      this.logger.error({ err: error, ticketOwnerId: payload.userId, channelId: channel.id }, 'Failed to persist general ticket.');
+      await channel.delete('Rolling back general ticket creation.');
+      throw error;
+    }
+  }
+}

--- a/src/domain/repositories/ITicketParticipantRepository.ts
+++ b/src/domain/repositories/ITicketParticipantRepository.ts
@@ -1,0 +1,25 @@
+// =============================================================================
+// RUTA: src/domain/repositories/ITicketParticipantRepository.ts
+// =============================================================================
+
+import type { Transactional } from '@/domain/repositories/transaction';
+
+export interface TicketParticipant {
+  readonly ticketId: number;
+  readonly userId: bigint;
+  readonly role: string | null;
+  readonly joinedAt: Date;
+}
+
+export interface AddParticipantInput {
+  readonly ticketId: number;
+  readonly userId: bigint;
+  readonly role?: string | null;
+  readonly joinedAt?: Date;
+}
+
+export interface ITicketParticipantRepository extends Transactional<ITicketParticipantRepository> {
+  addParticipant(input: AddParticipantInput): Promise<void>;
+  listByTicket(ticketId: number): Promise<readonly TicketParticipant[]>;
+  isParticipant(ticketId: number, userId: bigint): Promise<boolean>;
+}

--- a/src/domain/repositories/ITicketPolicyRepository.ts
+++ b/src/domain/repositories/ITicketPolicyRepository.ts
@@ -1,0 +1,16 @@
+// =============================================================================
+// RUTA: src/domain/repositories/ITicketPolicyRepository.ts
+// =============================================================================
+
+import type { TicketType } from '@/domain/entities/types';
+import type { Transactional } from '@/domain/repositories/transaction';
+
+export interface TicketPolicySnapshot {
+  readonly openCount: number;
+  readonly lastOpenedAt?: Date;
+  readonly lastClosedAt?: Date;
+}
+
+export interface ITicketPolicyRepository extends Transactional<ITicketPolicyRepository> {
+  getSnapshot(ownerId: bigint, type: TicketType): Promise<TicketPolicySnapshot>;
+}

--- a/src/domain/repositories/ITicketRepository.ts
+++ b/src/domain/repositories/ITicketRepository.ts
@@ -26,6 +26,7 @@ export interface ITicketRepository extends Transactional<ITicketRepository> {
   findById(id: number): Promise<Ticket | null>;
   findByChannelId(channelId: bigint): Promise<Ticket | null>;
   findOpenByOwner(ownerId: bigint): Promise<readonly Ticket[]>;
+  findRecentByOwner(ownerId: bigint, limit?: number): Promise<readonly Ticket[]>;
   update(ticket: Ticket): Promise<void>;
   delete(id: number): Promise<void>;
   countOpenByOwner(ownerId: bigint): Promise<number>;

--- a/src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
@@ -1,0 +1,83 @@
+// =============================================================================
+// RUTA: src/infrastructure/repositories/PrismaTicketParticipantRepository.ts
+// =============================================================================
+
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import type {
+  AddParticipantInput,
+  ITicketParticipantRepository,
+  TicketParticipant,
+} from '@/domain/repositories/ITicketParticipantRepository';
+import type { TransactionContext } from '@/domain/repositories/transaction';
+
+type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
+
+type PrismaTicketParticipant = Prisma.TicketParticipantGetPayload<unknown>;
+
+export class PrismaTicketParticipantRepository implements ITicketParticipantRepository {
+  public constructor(private readonly prisma: PrismaClientLike) {}
+
+  public withTransaction(context: TransactionContext): ITicketParticipantRepository {
+    if (!PrismaTicketParticipantRepository.isTransactionClient(context)) {
+      throw new Error('Invalid Prisma transaction context provided to ticket participant repository.');
+    }
+
+    return new PrismaTicketParticipantRepository(context);
+  }
+
+  public async addParticipant(input: AddParticipantInput): Promise<void> {
+    await this.prisma.ticketParticipant.upsert({
+      where: {
+        ticketId_userId: {
+          ticketId: input.ticketId,
+          userId: input.userId,
+        },
+      },
+      update: {
+        role: input.role ?? null,
+        joinedAt: input.joinedAt ?? new Date(),
+      },
+      create: {
+        ticketId: input.ticketId,
+        userId: input.userId,
+        role: input.role ?? null,
+        joinedAt: input.joinedAt ?? new Date(),
+      },
+    });
+  }
+
+  public async listByTicket(ticketId: number): Promise<readonly TicketParticipant[]> {
+    const participants = await this.prisma.ticketParticipant.findMany({
+      where: { ticketId },
+    });
+
+    return participants.map(PrismaTicketParticipantRepository.mapParticipant);
+  }
+
+  public async isParticipant(ticketId: number, userId: bigint): Promise<boolean> {
+    const participant = await this.prisma.ticketParticipant.findUnique({
+      where: {
+        ticketId_userId: {
+          ticketId,
+          userId,
+        },
+      },
+    });
+
+    return participant !== null;
+  }
+
+  private static mapParticipant(participant: PrismaTicketParticipant): TicketParticipant {
+    return {
+      ticketId: participant.ticketId,
+      userId: participant.userId,
+      role: participant.role ?? null,
+      joinedAt: participant.joinedAt,
+    };
+  }
+
+  private static isTransactionClient(value: TransactionContext): value is Prisma.TransactionClient {
+    return typeof value === 'object' && value !== null && 'ticketParticipant' in value;
+  }
+}

--- a/src/infrastructure/repositories/PrismaTicketPolicyRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketPolicyRepository.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// RUTA: src/infrastructure/repositories/PrismaTicketPolicyRepository.ts
+// =============================================================================
+
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import { TicketStatus, type TicketType } from '@/domain/entities/types';
+import type {
+  ITicketPolicyRepository,
+  TicketPolicySnapshot,
+} from '@/domain/repositories/ITicketPolicyRepository';
+import type { TransactionContext } from '@/domain/repositories/transaction';
+
+type PrismaClientLike = PrismaClient | Prisma.TransactionClient;
+
+export class PrismaTicketPolicyRepository implements ITicketPolicyRepository {
+  public constructor(private readonly prisma: PrismaClientLike) {}
+
+  public withTransaction(context: TransactionContext): ITicketPolicyRepository {
+    if (!PrismaTicketPolicyRepository.isTransactionClient(context)) {
+      throw new Error('Invalid Prisma transaction context provided to ticket policy repository.');
+    }
+
+    return new PrismaTicketPolicyRepository(context);
+  }
+
+  public async getSnapshot(ownerId: bigint, type: TicketType): Promise<TicketPolicySnapshot> {
+    const [openCount, lastOpened, lastClosed] = await Promise.all([
+      this.prisma.ticket.count({
+        where: {
+          ownerId,
+          type,
+          status: { in: [TicketStatus.OPEN, TicketStatus.CONFIRMED, TicketStatus.CLAIMED] },
+        },
+      }),
+      this.prisma.ticket.findFirst({
+        where: {
+          ownerId,
+          type,
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      }),
+      this.prisma.ticket.findFirst({
+        where: {
+          ownerId,
+          type,
+          status: TicketStatus.CLOSED,
+          closedAt: { not: null },
+        },
+        orderBy: { closedAt: 'desc' },
+        select: { closedAt: true },
+      }),
+    ]);
+
+    return {
+      openCount,
+      lastOpenedAt: lastOpened?.createdAt,
+      lastClosedAt: lastClosed?.closedAt ?? undefined,
+    };
+  }
+
+  private static isTransactionClient(value: TransactionContext): value is Prisma.TransactionClient {
+    return typeof value === 'object' && value !== null && 'ticket' in value;
+  }
+}

--- a/src/infrastructure/repositories/PrismaTicketRepository.ts
+++ b/src/infrastructure/repositories/PrismaTicketRepository.ts
@@ -95,6 +95,17 @@ export class PrismaTicketRepository implements ITicketRepository {
     return tickets.map((ticket) => this.toDomain(ticket));
   }
 
+  public async findRecentByOwner(ownerId: bigint, limit = 10): Promise<readonly Ticket[]> {
+    const tickets = await this.prisma.ticket.findMany({
+      where: { ownerId },
+      include: { middlemanClaim: true },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+
+    return tickets.map((ticket) => this.toDomain(ticket));
+  }
+
   public async update(ticket: Ticket): Promise<void> {
     await this.prisma.ticket.update({
       where: { id: ticket.id },

--- a/src/presentation/commands/index.ts
+++ b/src/presentation/commands/index.ts
@@ -6,9 +6,10 @@ import { commandRegistry, getRegisteredCommands, registerCommands, serializeComm
 import { helpCommand } from '@/presentation/commands/general/help';
 import { pingCommand } from '@/presentation/commands/general/ping';
 import { middlemanCommand } from '@/presentation/commands/middleman/middleman';
+import { ticketCommand } from '@/presentation/commands/tickets/ticket';
 import type { Command } from '@/presentation/commands/types';
 
-const commands: Command[] = [pingCommand, helpCommand, middlemanCommand];
+const commands: Command[] = [pingCommand, helpCommand, middlemanCommand, ticketCommand];
 
 registerCommands(commands);
 

--- a/src/presentation/commands/tickets/ticket.ts
+++ b/src/presentation/commands/tickets/ticket.ts
@@ -1,0 +1,203 @@
+// =============================================================================
+// RUTA: src/presentation/commands/tickets/ticket.ts
+// =============================================================================
+
+import {
+  ChannelType,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type TextChannel,
+} from 'discord.js';
+
+import { OpenGeneralTicketUseCase } from '@/application/usecases/tickets/OpenGeneralTicketUseCase';
+import { CloseGeneralTicketUseCase } from '@/application/usecases/tickets/CloseGeneralTicketUseCase';
+import { ListUserTicketsUseCase } from '@/application/usecases/tickets/ListUserTicketsUseCase';
+import { TicketType } from '@/domain/entities/types';
+import { prisma } from '@/infrastructure/db/prisma';
+import { PrismaTicketRepository } from '@/infrastructure/repositories/PrismaTicketRepository';
+import { PrismaTicketParticipantRepository } from '@/infrastructure/repositories/PrismaTicketParticipantRepository';
+import { PrismaTicketPolicyRepository } from '@/infrastructure/repositories/PrismaTicketPolicyRepository';
+import type { Command } from '@/presentation/commands/types';
+import { buildTicketQuickOpenRow, registerTicketQuickOpenHandler } from '@/presentation/components/tickets/TicketQuickOpenSelect';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+import { TicketNotFoundError, UnauthorizedActionError } from '@/shared/errors/domain.errors';
+import { logger } from '@/shared/logger/pino';
+
+const ticketRepo = new PrismaTicketRepository(prisma);
+const policyRepo = new PrismaTicketPolicyRepository(prisma);
+const participantRepo = new PrismaTicketParticipantRepository(prisma);
+
+const openUseCase = new OpenGeneralTicketUseCase(ticketRepo, policyRepo, participantRepo, prisma, logger, embedFactory);
+const closeUseCase = new CloseGeneralTicketUseCase(ticketRepo, participantRepo, prisma, logger, embedFactory);
+const listUseCase = new ListUserTicketsUseCase(ticketRepo, logger);
+
+registerTicketQuickOpenHandler(openUseCase);
+
+const ensureTextChannel = (interaction: ChatInputCommandInteraction): TextChannel => {
+  if (!interaction.guild) {
+    throw new UnauthorizedActionError('ticket:command:guild-only');
+  }
+
+  const channel = interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) {
+    throw new UnauthorizedActionError('ticket:command:channel');
+  }
+
+  return channel;
+};
+
+const handleOpen = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const guild = interaction.guild;
+  if (!guild) {
+    throw new UnauthorizedActionError('ticket:open:guild-only');
+  }
+
+  const type = interaction.options.getString('type', true) as TicketType;
+  const context = interaction.options.getString('context', true);
+  const partnerTag = interaction.options.getString('partner') ?? undefined;
+
+  await interaction.deferReply({ ephemeral: true });
+  const result = await openUseCase.execute(
+    {
+      userId: interaction.user.id,
+      guildId: guild.id,
+      type,
+      context,
+      partnerTag,
+    },
+    guild,
+  );
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.success({
+        title: 'Ticket creado',
+        description: `Se creó el ticket <#${result.channel.id}> para el tipo **${type}**.`,
+      }),
+    ],
+    components: [buildTicketQuickOpenRow()],
+  });
+};
+
+const handleClose = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  const channel = ensureTextChannel(interaction);
+  const ticket = await ticketRepo.findByChannelId(BigInt(channel.id));
+
+  if (!ticket) {
+    throw new TicketNotFoundError(channel.id);
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+  await closeUseCase.execute(ticket.id, interaction.user.id, channel);
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.success({
+        title: 'Ticket cerrado',
+        description: 'El ticket se marcó como cerrado correctamente.',
+      }),
+    ],
+  });
+};
+
+const handleList = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+  if (!interaction.guild) {
+    throw new UnauthorizedActionError('ticket:list:guild-only');
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+  const tickets = await listUseCase.execute(interaction.user.id, 10);
+
+  const openDescription = tickets.open.length
+    ? tickets.open.map((ticket) => `• #${ticket.id} — **${ticket.type}** (${ticket.status})`).join('\n')
+    : 'No tienes tickets abiertos.';
+
+  const recentDescription = tickets.recent.length
+    ? tickets.recent.map((ticket) => {
+        const status = ticket.closedAt ? `cerrado el ${ticket.closedAt.toLocaleString('es-ES')}` : 'abierto';
+        return `• #${ticket.id} — **${ticket.type}** (${status})`;
+      }).join('\n')
+    : 'No se encontraron tickets recientes.';
+
+  await interaction.editReply({
+    embeds: [
+      embedFactory.info({
+        title: 'Historial de tickets',
+        fields: [
+          { name: 'Abiertos', value: openDescription },
+          { name: 'Recientes', value: recentDescription },
+        ],
+      }),
+    ],
+    components: [buildTicketQuickOpenRow()],
+  });
+};
+
+export const ticketCommand: Command = {
+  category: 'Tickets',
+  data: new SlashCommandBuilder()
+    .setName('ticket')
+    .setDescription('Gestiona tickets generales de Dedos Shop')
+    .addSubcommand((sub) =>
+      sub
+        .setName('open')
+        .setDescription('Abre un nuevo ticket general')
+        .addStringOption((option) =>
+          option
+            .setName('type')
+            .setDescription('Tipo de ticket a crear')
+            .setRequired(true)
+            .addChoices(
+              { name: 'Comprar', value: TicketType.BUY },
+              { name: 'Vender', value: TicketType.SELL },
+              { name: 'Robux', value: TicketType.ROBUX },
+              { name: 'Nitro', value: TicketType.NITRO },
+              { name: 'Decoración', value: TicketType.DECOR },
+            ),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('context')
+            .setDescription('Describe brevemente qué necesitas')
+            .setRequired(true)
+            .setMinLength(10)
+            .setMaxLength(1000),
+        )
+        .addStringOption((option) =>
+          option
+            .setName('partner')
+            .setDescription('Menciona a la otra persona involucrada (opcional)')
+            .setRequired(false),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('close')
+        .setDescription('Cierra el ticket actual'),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('list')
+        .setDescription('Consulta tus tickets abiertos y recientes'),
+    ),
+  execute: async (interaction) => {
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'open') {
+      await handleOpen(interaction);
+      return;
+    }
+
+    if (subcommand === 'close') {
+      await handleClose(interaction);
+      return;
+    }
+
+    await handleList(interaction);
+  },
+  examples: [
+    '/ticket open type:BUY context:"Busco comprar limiteds"',
+    '/ticket close',
+    '/ticket list',
+  ],
+};

--- a/src/presentation/components/tickets/TicketQuickOpenSelect.ts
+++ b/src/presentation/components/tickets/TicketQuickOpenSelect.ts
@@ -1,0 +1,74 @@
+// =============================================================================
+// RUTA: src/presentation/components/tickets/TicketQuickOpenSelect.ts
+// =============================================================================
+
+import { ActionRowBuilder, StringSelectMenuBuilder } from 'discord.js';
+
+import type { OpenGeneralTicketUseCase } from '@/application/usecases/tickets/OpenGeneralTicketUseCase';
+import { TicketType } from '@/domain/entities/types';
+import { registerSelectMenuHandler } from '@/presentation/components/registry';
+import { embedFactory } from '@/presentation/embeds/EmbedFactory';
+
+const CUSTOM_ID = 'ticket:quick-open';
+
+const QUICK_CONTEXT: Record<Exclude<TicketType, TicketType.MM>, string> = {
+  [TicketType.BUY]: 'Ticket rápido de compra generado desde el selector.',
+  [TicketType.SELL]: 'Ticket rápido de venta generado desde el selector.',
+  [TicketType.ROBUX]: 'Ticket rápido de intercambio de Robux generado desde el selector.',
+  [TicketType.NITRO]: 'Ticket rápido relacionado con Nitro generado desde el selector.',
+  [TicketType.DECOR]: 'Ticket rápido de decoración generado desde el selector.',
+};
+
+export const buildTicketQuickOpenRow = () =>
+  new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(CUSTOM_ID)
+      .setPlaceholder('Abrir ticket rápido')
+      .addOptions(
+        { label: 'Comprar', description: 'Solicita asistencia para comprar', value: TicketType.BUY },
+        { label: 'Vender', description: 'Publica una venta y recibe soporte', value: TicketType.SELL },
+        { label: 'Robux', description: 'Gestiona intercambios de Robux', value: TicketType.ROBUX },
+        { label: 'Nitro', description: 'Solicita soporte para Nitro', value: TicketType.NITRO },
+        { label: 'Decoración', description: 'Canales de decoración y gráficos', value: TicketType.DECOR },
+      ),
+  );
+
+export const registerTicketQuickOpenHandler = (useCase: OpenGeneralTicketUseCase): void => {
+  registerSelectMenuHandler(CUSTOM_ID, async (interaction) => {
+    if (!interaction.guild) {
+      await interaction.reply({
+        embeds: [
+          embedFactory.error({
+            title: 'Acción no disponible',
+            description: 'Este selector solo funciona dentro de un servidor.',
+          }),
+        ],
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const selected = interaction.values[0] as Exclude<TicketType, TicketType.MM>;
+    const context = QUICK_CONTEXT[selected];
+
+    await interaction.deferReply({ ephemeral: true });
+    const result = await useCase.execute(
+      {
+        userId: interaction.user.id,
+        guildId: interaction.guild.id,
+        type: selected,
+        context,
+      },
+      interaction.guild,
+    );
+
+    await interaction.editReply({
+      embeds: [
+        embedFactory.success({
+          title: 'Ticket creado',
+          description: `Se creó el ticket <#${result.channel.id}> con el tipo **${selected}**.`,
+        }),
+      ],
+    });
+  });
+};

--- a/src/shared/errors/domain.errors.ts
+++ b/src/shared/errors/domain.errors.ts
@@ -81,6 +81,17 @@ export class TooManyOpenTicketsError extends DedosError {
   }
 }
 
+export class TicketCooldownError extends DedosError {
+  public constructor(availableAt: Date) {
+    super({
+      code: 'TICKET_COOLDOWN_ACTIVE',
+      message: 'Debes esperar antes de abrir otro ticket de este tipo.',
+      metadata: { availableAt: availableAt.toISOString() },
+      exposeMessage: true,
+    });
+  }
+}
+
 export class InvalidTradeStateError extends DedosError {
   public constructor(current: unknown, expected: unknown) {
     super({

--- a/tests/integration/tickets/prisma-ticket-repositories.test.ts
+++ b/tests/integration/tickets/prisma-ticket-repositories.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PrismaTicketParticipantRepository } from '@/infrastructure/repositories/PrismaTicketParticipantRepository';
+import { PrismaTicketPolicyRepository } from '@/infrastructure/repositories/PrismaTicketPolicyRepository';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+
+interface StoredTicket {
+  id: number;
+  ownerId: bigint;
+  guildId: bigint;
+  channelId: bigint;
+  type: TicketType;
+  status: TicketStatus;
+  createdAt: Date;
+  closedAt?: Date | null;
+}
+
+interface StoredParticipant {
+  ticketId: number;
+  userId: bigint;
+  role: string | null;
+  joinedAt: Date;
+}
+
+class FakePrismaClient {
+  private tickets = new Map<number, StoredTicket>();
+  private participants = new Map<string, StoredParticipant>();
+  private ticketSeq = 1;
+
+  public readonly ticket = {
+    create: async (args: any) => {
+      const id = this.ticketSeq++;
+      const record: StoredTicket = {
+        id,
+        ownerId: args.data.ownerId,
+        guildId: args.data.guildId,
+        channelId: args.data.channelId,
+        type: args.data.type,
+        status: args.data.status ?? TicketStatus.OPEN,
+        createdAt: args.data.createdAt ?? new Date(),
+        closedAt: args.data.closedAt ?? null,
+      };
+      this.tickets.set(id, record);
+      return record;
+    },
+    count: async (args: any) => {
+      const statuses: TicketStatus[] | undefined = args.where?.status?.in;
+      let count = 0;
+      for (const ticket of this.tickets.values()) {
+        if (ticket.ownerId !== args.where.ownerId) {
+          continue;
+        }
+        if (ticket.type !== args.where.type) {
+          continue;
+        }
+        if (statuses && !statuses.includes(ticket.status)) {
+          continue;
+        }
+        count++;
+      }
+      return count;
+    },
+    findFirst: async (args: any) => {
+      const tickets = Array.from(this.tickets.values()).filter((ticket) => {
+        if (args.where?.ownerId !== undefined && ticket.ownerId !== args.where.ownerId) {
+          return false;
+        }
+        if (args.where?.type !== undefined && ticket.type !== args.where.type) {
+          return false;
+        }
+        if (args.where?.status !== undefined && ticket.status !== args.where.status) {
+          return false;
+        }
+        if (args.where?.closedAt?.not === null && ticket.closedAt === null) {
+          return false;
+        }
+        return true;
+      });
+
+      if (tickets.length === 0) {
+        return null;
+      }
+
+      tickets.sort((a, b) => {
+        const order = args.orderBy?.createdAt === 'desc' || args.orderBy?.closedAt === 'desc' ? -1 : 1;
+        const left = args.orderBy?.createdAt ? a.createdAt.getTime() : (a.closedAt?.getTime() ?? 0);
+        const right = args.orderBy?.createdAt ? b.createdAt.getTime() : (b.closedAt?.getTime() ?? 0);
+        return order * (left - right);
+      });
+
+      const ticket = tickets[0];
+
+      if (args.select?.createdAt) {
+        return { createdAt: ticket.createdAt };
+      }
+
+      if (args.select?.closedAt) {
+        return { closedAt: ticket.closedAt };
+      }
+
+      return ticket;
+    },
+  };
+
+  public readonly ticketParticipant = {
+    upsert: async (args: any) => {
+      const key = `${args.where.ticketId_userId.ticketId}:${args.where.ticketId_userId.userId}`;
+      const participant: StoredParticipant = {
+        ticketId: args.create.ticketId,
+        userId: args.create.userId,
+        role: args.create.role ?? null,
+        joinedAt: args.create.joinedAt ?? new Date(),
+      };
+      this.participants.set(key, participant);
+      return participant;
+    },
+    findMany: async (args: any) => {
+      return Array.from(this.participants.values()).filter((participant) => participant.ticketId === args.where.ticketId);
+    },
+    findUnique: async (args: any) => {
+      const key = `${args.where.ticketId_userId.ticketId}:${args.where.ticketId_userId.userId}`;
+      return this.participants.get(key) ?? null;
+    },
+  };
+
+  public async $transaction<T>(callback: (tx: FakePrismaClient) => Promise<T>): Promise<T> {
+    return callback(this);
+  }
+}
+
+describe('Prisma ticket repositories', () => {
+  let prisma: FakePrismaClient;
+
+  beforeEach(() => {
+    prisma = new FakePrismaClient();
+  });
+
+  it('should return policy snapshot with counts and timestamps', async () => {
+    const repo = new PrismaTicketPolicyRepository(prisma as any);
+
+    await prisma.ticket.create({
+      data: {
+        ownerId: 1n,
+        guildId: 1n,
+        channelId: 10n,
+        type: TicketType.BUY,
+        status: TicketStatus.OPEN,
+        createdAt: new Date('2024-06-01T10:00:00.000Z'),
+      },
+    });
+    await prisma.ticket.create({
+      data: {
+        ownerId: 1n,
+        guildId: 1n,
+        channelId: 11n,
+        type: TicketType.BUY,
+        status: TicketStatus.CLOSED,
+        createdAt: new Date('2024-05-31T09:00:00.000Z'),
+        closedAt: new Date('2024-05-31T12:00:00.000Z'),
+      },
+    });
+
+    const snapshot = await repo.getSnapshot(1n, TicketType.BUY);
+    expect(snapshot.openCount).toBe(1);
+    expect(snapshot.lastOpenedAt?.toISOString()).toBe('2024-06-01T10:00:00.000Z');
+    expect(snapshot.lastClosedAt?.toISOString()).toBe('2024-05-31T12:00:00.000Z');
+  });
+
+  it('should manage participants with upsert semantics', async () => {
+    const repo = new PrismaTicketParticipantRepository(prisma as any);
+
+    await repo.addParticipant({ ticketId: 100, userId: 55n, role: 'OWNER', joinedAt: new Date('2024-06-01T12:00:00.000Z') });
+    await repo.addParticipant({ ticketId: 100, userId: 60n, role: 'PARTNER' });
+
+    const participants = await repo.listByTicket(100);
+    expect(participants).toHaveLength(2);
+
+    const isParticipant = await repo.isParticipant(100, 55n);
+    expect(isParticipant).toBe(true);
+  });
+});

--- a/tests/unit/application/tickets/open-general-ticket.usecase.test.ts
+++ b/tests/unit/application/tickets/open-general-ticket.usecase.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { OpenGeneralTicketUseCase } from '@/application/usecases/tickets/OpenGeneralTicketUseCase';
+import { Ticket } from '@/domain/entities/Ticket';
+import { TicketStatus, TicketType } from '@/domain/entities/types';
+import type { ITicketRepository } from '@/domain/repositories/ITicketRepository';
+import type { ITicketParticipantRepository } from '@/domain/repositories/ITicketParticipantRepository';
+import type { ITicketPolicyRepository } from '@/domain/repositories/ITicketPolicyRepository';
+import { TicketCooldownError, TooManyOpenTicketsError } from '@/shared/errors/domain.errors';
+
+const createGuildMock = () => {
+  const send = vi.fn();
+  const deleteChannel = vi.fn();
+
+  const channel = {
+    id: '123456789012345678',
+    send,
+    delete: deleteChannel,
+  };
+
+  const guild = {
+    id: '987654321098765432',
+    roles: { everyone: { id: 'everyone-role' } },
+    members: { me: { id: 'bot-id' } },
+    channels: {
+      create: vi.fn().mockResolvedValue(channel),
+    },
+  } as any;
+
+  return { guild, channel, send, deleteChannel };
+};
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+} as any;
+
+const prisma = {
+  $transaction: vi.fn(async (callback: any) => callback({})),
+} as any;
+
+const createTicketRepo = () => {
+  const repo: ITicketRepository = {
+    withTransaction: vi.fn().mockReturnThis(),
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByChannelId: vi.fn(),
+    findOpenByOwner: vi.fn(),
+    findRecentByOwner: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    countOpenByOwner: vi.fn(),
+    isParticipant: vi.fn(),
+  };
+
+  return repo;
+};
+
+const createPolicyRepo = () => {
+  const repo: ITicketPolicyRepository = {
+    withTransaction: vi.fn().mockReturnThis(),
+    getSnapshot: vi.fn(),
+  };
+
+  return repo;
+};
+
+const createParticipantRepo = () => {
+  const repo: ITicketParticipantRepository = {
+    withTransaction: vi.fn().mockReturnThis(),
+    addParticipant: vi.fn(),
+    listByTicket: vi.fn(),
+    isParticipant: vi.fn(),
+  };
+
+  return repo;
+};
+
+describe('OpenGeneralTicketUseCase', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-01T12:00:00.000Z'));
+  });
+
+  it('should prevent opening tickets when limit is reached', async () => {
+    const ticketRepo = createTicketRepo();
+    const policyRepo = createPolicyRepo();
+    const participantRepo = createParticipantRepo();
+    policyRepo.getSnapshot.mockResolvedValue({
+      openCount: 3,
+      lastOpenedAt: new Date('2024-06-01T10:00:00.000Z'),
+      lastClosedAt: new Date('2024-06-01T11:00:00.000Z'),
+    });
+
+    const useCase = new OpenGeneralTicketUseCase(ticketRepo, policyRepo, participantRepo, prisma, logger);
+    const { guild } = createGuildMock();
+
+    await expect(
+      useCase.execute(
+        {
+          userId: '111111111111111111',
+          guildId: guild.id,
+          type: TicketType.BUY,
+          context: 'Quiero comprar un ítem de prueba',
+        },
+        guild,
+      ),
+    ).rejects.toBeInstanceOf(TooManyOpenTicketsError);
+    expect(guild.channels.create).not.toHaveBeenCalled();
+  });
+
+  it('should enforce cooldown based on last open ticket', async () => {
+    const ticketRepo = createTicketRepo();
+    const policyRepo = createPolicyRepo();
+    const participantRepo = createParticipantRepo();
+    policyRepo.getSnapshot.mockResolvedValue({
+      openCount: 0,
+      lastOpenedAt: new Date('2024-06-01T11:45:00.000Z'),
+      lastClosedAt: new Date('2024-06-01T11:50:00.000Z'),
+    });
+
+    const useCase = new OpenGeneralTicketUseCase(ticketRepo, policyRepo, participantRepo, prisma, logger);
+    const { guild } = createGuildMock();
+
+    await expect(
+      useCase.execute(
+        {
+          userId: '111111111111111111',
+          guildId: guild.id,
+          type: TicketType.BUY,
+          context: 'Solicitud dentro de cooldown',
+        },
+        guild,
+      ),
+    ).rejects.toBeInstanceOf(TicketCooldownError);
+  });
+
+  it('should create ticket and register participants when allowed', async () => {
+    const ticketRepo = createTicketRepo();
+    const policyRepo = createPolicyRepo();
+    const participantRepo = createParticipantRepo();
+    policyRepo.getSnapshot.mockResolvedValue({
+      openCount: 0,
+      lastOpenedAt: new Date('2024-05-31T12:00:00.000Z'),
+      lastClosedAt: new Date('2024-05-31T13:00:00.000Z'),
+    });
+
+    const ticket = new Ticket(
+      25,
+      999n,
+      555n,
+      111n,
+      TicketType.SELL,
+      TicketStatus.OPEN,
+      new Date('2024-06-01T12:00:00.000Z'),
+    );
+
+    ticketRepo.create.mockResolvedValue(ticket);
+
+    const useCase = new OpenGeneralTicketUseCase(ticketRepo, policyRepo, participantRepo, prisma, logger);
+    const { guild, channel } = createGuildMock();
+
+    const result = await useCase.execute(
+      {
+        userId: '111111111111111111',
+        guildId: guild.id,
+        type: TicketType.SELL,
+        context: 'Descripción detallada del ticket',
+      },
+      guild,
+    );
+
+    expect(result.ticket).toBe(ticket);
+    expect(result.channel).toEqual(channel);
+    expect(ticketRepo.create).toHaveBeenCalled();
+    expect(participantRepo.addParticipant).toHaveBeenCalledWith({
+      ticketId: ticket.id,
+      userId: 111111111111111111n,
+      role: 'OWNER',
+    });
+    expect(channel.send).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Zod DTOs and use cases to manage general ticket creation, closing, and listing with cooldown enforcement
- implement Prisma repositories for ticket policies and participants plus expose the /ticket command with quick-open select components
- document ticket limits and cover the flow with unit and integration tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dde61ab9c88326aa634a6a68e245a8